### PR TITLE
feautre: 신고 기능

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,8 @@ enum PlaceStatus {
 enum ReCreeshotStatus {
   ACTIVE
   REPORTED
-  HIDDEN
+  HIDDEN        // 관리자가 직접 숨김
+  REPORT_HIDDEN // 신고 처리로 인한 숨김
   DELETED
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,21 @@ enum ContentType {
   RECREESHOT
 }
 
+enum ReportReason {
+  SPAM
+  INAPPROPRIATE
+  HARASSMENT
+  FALSE_INFORMATION
+  COPYRIGHT
+  OTHER
+}
+
+enum ReportStatus {
+  PENDING    // 미처리
+  DISMISSED  // 기각
+  RESOLVED   // 처리완료
+}
+
 // ─── Models ───────────────────────────────────────────────────────────────────
 
 model User {
@@ -87,6 +102,7 @@ model User {
   reCreeshots     ReCreeshot[]
   saves           Save[]
   reCreeshotLikes ReCreeshotLike[]
+  reports         Report[]
 }
 
 model Topic {
@@ -175,6 +191,7 @@ model Post {
   postImages  PostImage[]
   postSources PostSource[]
   homeBanners HomeBanner[]
+  reports     Report[]
 }
 
 model PostImage {
@@ -310,6 +327,7 @@ model ReCreeshot {
   reCreeshotTopics ReCreeshotTopic[]
   reCreeshotTags   ReCreeshotTag[]
   reCreeshotLikes  ReCreeshotLike[]
+  reports          Report[]
 }
 
 // ─── M:N 조인 테이블 ──────────────────────────────────────────────────────────
@@ -431,6 +449,26 @@ model CuratedSection {
 
   filterTopic Topic? @relation("FilterTopic", fields: [filterTopicId], references: [id])
   filterTag   Tag?   @relation("FilterTag", fields: [filterTagId], references: [id])
+}
+
+model Report {
+  id           String       @id @default(uuid()) @db.Uuid
+  reason       ReportReason
+  description  String?
+  status       ReportStatus @default(PENDING)
+  reporterId   String       @db.Uuid
+  postId       String?      @db.Uuid
+  reCreeshotId String?      @db.Uuid
+  createdAt    DateTime     @default(now())
+  resolvedAt   DateTime?
+
+  reporter   User        @relation(fields: [reporterId], references: [id])
+  post       Post?       @relation(fields: [postId], references: [id], onDelete: Cascade)
+  reCreeshot ReCreeshot? @relation(fields: [reCreeshotId], references: [id], onDelete: Cascade)
+
+  @@index([postId])
+  @@index([reCreeshotId])
+  @@index([status])
 }
 
 model PopularSearch {

--- a/src/app/(user)/_actions/report-actions.ts
+++ b/src/app/(user)/_actions/report-actions.ts
@@ -11,47 +11,64 @@ export async function createReport(data: {
   postId?: string;
   reCreeshotId?: string;
 }): Promise<{ error?: string }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { error: "unauthenticated" };
 
-  if (!user) return { error: "unauthenticated" };
+    // 본인 콘텐츠 신고 방지
+    if (data.postId) {
+      const post = await prisma.post.findUnique({
+        where: { id: data.postId },
+        select: { authorId: true },
+      });
+      if (post?.authorId === user.id) return { error: "own_content" };
+    }
+    if (data.reCreeshotId) {
+      const shot = await prisma.reCreeshot.findUnique({
+        where: { id: data.reCreeshotId },
+        select: { userId: true },
+      });
+      if (shot?.userId === user.id) return { error: "own_content" };
+    }
 
-  // 같은 대상에 PENDING 신고가 이미 있으면 중복 방지
-  const existing = await prisma.report.findFirst({
-    where: {
-      reporterId: user.id,
-      postId: data.postId ?? null,
-      reCreeshotId: data.reCreeshotId ?? null,
-      status: "PENDING",
-    },
-  });
-  if (existing) return { error: "already_reported" };
-
-  await prisma.$transaction(async (tx) => {
-    await tx.report.create({
-      data: {
-        reason: data.reason,
-        description: data.description ?? null,
+    // 같은 대상에 PENDING 신고가 이미 있으면 중복 방지
+    const existing = await prisma.report.findFirst({
+      where: {
         reporterId: user.id,
         postId: data.postId ?? null,
         reCreeshotId: data.reCreeshotId ?? null,
+        status: "PENDING",
       },
     });
+    if (existing) return { error: "already_reported" };
 
-    // 리크리샷 신고 시 status를 REPORTED로 변경
-    if (data.reCreeshotId) {
-      await tx.reCreeshot.update({
-        where: { id: data.reCreeshotId },
-        data: { status: "REPORTED" },
+    await prisma.$transaction(async (tx) => {
+      await tx.report.create({
+        data: {
+          reason: data.reason,
+          description: data.description ?? null,
+          reporterId: user.id,
+          postId: data.postId ?? null,
+          reCreeshotId: data.reCreeshotId ?? null,
+        },
       });
+
+      // 리크리샷 신고 시 status를 REPORTED로 변경
+      if (data.reCreeshotId) {
+        await tx.reCreeshot.update({
+          where: { id: data.reCreeshotId },
+          data: { status: "REPORTED" },
+        });
+      }
+    });
+
+    if (data.reCreeshotId) {
+      revalidatePath(`/explore/hall/${data.reCreeshotId}`);
     }
-  });
 
-  if (data.reCreeshotId) {
-    revalidatePath(`/explore/hall/${data.reCreeshotId}`);
+    return {};
+  } catch {
+    return { error: "server_error" };
   }
-
-  return {};
 }

--- a/src/app/(user)/_actions/report-actions.ts
+++ b/src/app/(user)/_actions/report-actions.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import type { ReportReason } from "@prisma/client";
+
+export async function createReport(data: {
+  reason: ReportReason;
+  description?: string;
+  postId?: string;
+  reCreeshotId?: string;
+}): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { error: "unauthenticated" };
+
+  // 같은 대상에 PENDING 신고가 이미 있으면 중복 방지
+  const existing = await prisma.report.findFirst({
+    where: {
+      reporterId: user.id,
+      postId: data.postId ?? null,
+      reCreeshotId: data.reCreeshotId ?? null,
+      status: "PENDING",
+    },
+  });
+  if (existing) return { error: "already_reported" };
+
+  await prisma.$transaction(async (tx) => {
+    await tx.report.create({
+      data: {
+        reason: data.reason,
+        description: data.description ?? null,
+        reporterId: user.id,
+        postId: data.postId ?? null,
+        reCreeshotId: data.reCreeshotId ?? null,
+      },
+    });
+
+    // 리크리샷 신고 시 status를 REPORTED로 변경
+    if (data.reCreeshotId) {
+      await tx.reCreeshot.update({
+        where: { id: data.reCreeshotId },
+        data: { status: "REPORTED" },
+      });
+    }
+  });
+
+  if (data.reCreeshotId) {
+    revalidatePath(`/explore/hall/${data.reCreeshotId}`);
+  }
+
+  return {};
+}

--- a/src/app/(user)/explore/hall/[id]/_components/HallDetailTopSection.tsx
+++ b/src/app/(user)/explore/hall/[id]/_components/HallDetailTopSection.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { ChevronLeft, MoreVertical, Download, Pencil, Trash2, Flag } from "lucide-react";
 import { toast } from "sonner";
 import { deleteReCreeshot } from "@/app/(user)/_actions/recreeshot-actions";
+import { ReportDialog } from "@/components/ReportDialog";
 
 interface Props {
   id: string;
@@ -22,6 +23,7 @@ export function HallDetailTopSection({ id, isOwner, imageUrl, referencePhotoUrl,
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
 
   useEffect(() => {
     let objectUrl: string | null = null;
@@ -156,12 +158,18 @@ export function HallDetailTopSection({ id, isOwner, imageUrl, referencePhotoUrl,
 
   function handleReport() {
     setMenuOpen(false);
-    toast.success("Report submitted. Thank you.");
+    setReportOpen(true);
   }
 
   return (
     <>
       <canvas ref={canvasRef} className="hidden" />
+
+      <ReportDialog
+        open={reportOpen}
+        onClose={() => setReportOpen(false)}
+        reCreeshotId={id}
+      />
 
       {/* 삭제 확인 다이얼로그 */}
       {showDeleteConfirm && (
@@ -212,31 +220,31 @@ export function HallDetailTopSection({ id, isOwner, imageUrl, referencePhotoUrl,
           {menuOpen && (
             <>
               <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
-              <div className="absolute top-10 right-0 z-20 bg-white/80 backdrop-blur-md rounded-xl shadow-lg overflow-hidden min-w-[160px]">
-                <button
-                  type="button"
-                  onClick={handleSave}
-                  className="flex items-center gap-2 w-full px-3.5 py-2.5 text-xs font-medium text-gray-800 hover:bg-gray-50 transition-colors border-b border-gray-100"
-                >
-                  <Download className="size-3.5 shrink-0" />
-                  Download
-                </button>
+              <div className="absolute top-10 right-0 z-20 bg-white/80 backdrop-blur-md rounded-xl shadow-md overflow-hidden min-w-[160px]">
                 {isOwner ? (
                   <>
                     <button
                       type="button"
-                      onClick={() => { setMenuOpen(false); router.push(`/explore/hall/${id}/edit`); }}
-                      className="flex items-center gap-2 w-full px-3.5 py-2.5 text-xs font-medium text-gray-800 hover:bg-gray-50 transition-colors border-b border-gray-100"
+                      onClick={handleSave}
+                      className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors border-b border-gray-100"
                     >
-                      <Pencil className="size-3.5 shrink-0" />
+                      <Download className="size-4 shrink-0" />
+                      Download
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setMenuOpen(false); router.push(`/explore/hall/${id}/edit`); }}
+                      className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors border-b border-gray-100"
+                    >
+                      <Pencil className="size-4 shrink-0" />
                       Edit
                     </button>
                     <button
                       type="button"
                       onClick={() => { setMenuOpen(false); setShowDeleteConfirm(true); }}
-                      className="flex items-center gap-2 w-full px-3.5 py-2.5 text-xs font-medium text-red-500 hover:bg-gray-50 transition-colors"
+                      className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-red-500 hover:bg-gray-50 transition-colors"
                     >
-                      <Trash2 className="size-3.5 shrink-0" />
+                      <Trash2 className="size-4 shrink-0" />
                       Delete
                     </button>
                   </>
@@ -244,9 +252,9 @@ export function HallDetailTopSection({ id, isOwner, imageUrl, referencePhotoUrl,
                   <button
                     type="button"
                     onClick={handleReport}
-                    className="flex items-center gap-2 w-full px-3.5 py-2.5 text-xs font-medium text-gray-800 hover:bg-gray-50 transition-colors"
+                    className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors"
                   >
-                    <Flag className="size-3.5 shrink-0" />
+                    <Flag className="size-4 shrink-0" />
                     Report
                   </button>
                 )}

--- a/src/app/(user)/explore/hall/[id]/_components/HallDetailTopSection.tsx
+++ b/src/app/(user)/explore/hall/[id]/_components/HallDetailTopSection.tsx
@@ -10,13 +10,14 @@ import { ReportDialog } from "@/components/ReportDialog";
 interface Props {
   id: string;
   isOwner: boolean;
+  isLoggedIn: boolean;
   imageUrl: string;
   referencePhotoUrl: string | null;
   matchScore: number | null;
   showBadge: boolean;
 }
 
-export function HallDetailTopSection({ id, isOwner, imageUrl, referencePhotoUrl, matchScore, showBadge }: Props) {
+export function HallDetailTopSection({ id, isOwner, isLoggedIn, imageUrl, referencePhotoUrl, matchScore, showBadge }: Props) {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [compositeUrl, setCompositeUrl] = useState<string | null>(null);
@@ -158,6 +159,10 @@ export function HallDetailTopSection({ id, isOwner, imageUrl, referencePhotoUrl,
 
   function handleReport() {
     setMenuOpen(false);
+    if (!isLoggedIn) {
+      toast.error("Please sign in to report content.");
+      return;
+    }
     setReportOpen(true);
   }
 

--- a/src/app/(user)/explore/hall/[id]/page.tsx
+++ b/src/app/(user)/explore/hall/[id]/page.tsx
@@ -51,8 +51,8 @@ export default async function HallDetailPage({
 
   if (!shot || shot.status === "DELETED") notFound();
 
-  // 숨김 처리된 리크리샷 안내 페이지
-  if (shot.status === "HIDDEN") {
+  // 숨김 처리된 리크리샷 안내 페이지 (직접 숨김 또는 신고로 인한 숨김)
+  if (shot.status === "HIDDEN" || shot.status === "REPORT_HIDDEN") {
     return (
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center h-12 px-2 bg-white border-b border-gray-100">
@@ -65,8 +65,12 @@ export default async function HallDetailPage({
             <EyeOff className="size-6 text-muted-foreground" />
           </div>
           <div className="space-y-1.5">
-            <p className="font-semibold text-base">관리자에 의해 숨김 처리된 리크리샷입니다.</p>
-            <p className="text-sm text-muted-foreground">이 콘텐츠는 현재 표시되지 않습니다.</p>
+            <p className="font-semibold text-base">This content is not available.</p>
+            <p className="text-sm text-muted-foreground">
+              {shot.status === "REPORT_HIDDEN"
+                ? "This recreeshot has been removed after a review."
+                : "This recreeshot has been hidden by an administrator."}
+            </p>
           </div>
         </div>
       </div>
@@ -100,6 +104,7 @@ export default async function HallDetailPage({
       <HallDetailTopSection
         id={id}
         isOwner={isOwner}
+        isLoggedIn={!!currentUser}
         imageUrl={shot.imageUrl}
         referencePhotoUrl={shot.referencePhotoUrl}
         matchScore={shot.matchScore}

--- a/src/app/(user)/posts/[slug]/_components/PostDetailHeader.tsx
+++ b/src/app/(user)/posts/[slug]/_components/PostDetailHeader.tsx
@@ -1,21 +1,64 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, MoreVertical, Flag } from "lucide-react";
+import { ReportDialog } from "@/components/ReportDialog";
 
-export function PostDetailHeader() {
+interface Props {
+  postId?: string;
+}
+
+export function PostDetailHeader({ postId }: Props) {
   const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 flex items-center h-12 px-3">
-      <button
-        type="button"
-        onClick={() => router.back()}
-        className="flex items-center justify-center h-8 w-8"
-      >
-        <ArrowLeft className="h-5 w-5 text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.8)]" />
-      </button>
+    <>
+      <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between h-12 px-3">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="flex items-center justify-center h-8 w-8"
+        >
+          <ArrowLeft className="h-5 w-5 text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.8)]" />
+        </button>
 
-    </div>
+        {postId && (
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setMenuOpen((v) => !v)}
+              className="flex items-center justify-center h-8 w-8"
+            >
+              <MoreVertical className="h-5 w-5 text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.8)]" />
+            </button>
+
+            {menuOpen && (
+              <>
+                <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+                <div className="absolute top-10 right-0 z-20 bg-white/80 backdrop-blur-md rounded-xl shadow-md overflow-hidden min-w-[160px]">
+                  <button
+                    type="button"
+                    onClick={() => { setMenuOpen(false); setReportOpen(true); }}
+                    className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors"
+                  >
+                    <Flag className="size-4 shrink-0" />
+                    Report
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ReportDialog
+        open={reportOpen}
+        onClose={() => setReportOpen(false)}
+        postId={postId}
+      />
+    </>
   );
 }

--- a/src/app/(user)/posts/[slug]/_components/PostDetailHeader.tsx
+++ b/src/app/(user)/posts/[slug]/_components/PostDetailHeader.tsx
@@ -3,13 +3,15 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, MoreVertical, Flag } from "lucide-react";
+import { toast } from "sonner";
 import { ReportDialog } from "@/components/ReportDialog";
 
 interface Props {
   postId?: string;
+  isLoggedIn?: boolean;
 }
 
-export function PostDetailHeader({ postId }: Props) {
+export function PostDetailHeader({ postId, isLoggedIn }: Props) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
@@ -41,7 +43,7 @@ export function PostDetailHeader({ postId }: Props) {
                 <div className="absolute top-10 right-0 z-20 bg-white/80 backdrop-blur-md rounded-xl shadow-md overflow-hidden min-w-[160px]">
                   <button
                     type="button"
-                    onClick={() => { setMenuOpen(false); setReportOpen(true); }}
+                    onClick={() => { setMenuOpen(false); if (!isLoggedIn) { toast.error("Please sign in to report content."); return; } setReportOpen(true); }}
                     className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors"
                   >
                     <Flag className="size-4 shrink-0" />

--- a/src/app/(user)/posts/[slug]/page.tsx
+++ b/src/app/(user)/posts/[slug]/page.tsx
@@ -196,7 +196,7 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
 
   return (
     <article className="pb-8 max-w-2xl mx-auto">
-      {!isPreview && <PostDetailHeader postId={post.id} />}
+      {!isPreview && <PostDetailHeader postId={post.id} isLoggedIn={!!currentUser} />}
       {isPreview && (
         <div className="bg-amber-100 text-amber-800 text-xs text-center py-2 font-medium">
           미리보기 모드 — 실제 발행 전 상태입니다

--- a/src/app/(user)/posts/[slug]/page.tsx
+++ b/src/app/(user)/posts/[slug]/page.tsx
@@ -196,7 +196,7 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
 
   return (
     <article className="pb-8 max-w-2xl mx-auto">
-      {!isPreview && <PostDetailHeader />}
+      {!isPreview && <PostDetailHeader postId={post.id} />}
       {isPreview && (
         <div className="bg-amber-100 text-amber-800 text-xs text-center py-2 font-medium">
           미리보기 모드 — 실제 발행 전 상태입니다

--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -17,6 +17,7 @@ import {
   Layers,
   Map,
   Video,
+  Flag,
 } from "lucide-react";
 import { signOut } from "@/lib/actions/auth";
 
@@ -41,6 +42,10 @@ const CURATION_MENUS = [
   { label: "recreeshot 관리", icon: Camera, href: "/admin/recreeshots" },
   { label: "가이드 영상", icon: Video, href: "/admin/guide-video" },
   { label: "인기 검색어", icon: TrendingUp, href: "/admin/popular-searches" },
+] as const;
+
+const MODERATION_MENUS = [
+  { label: "포스트 신고 관리", icon: Flag, href: "/admin/reports" },
 ] as const;
 
 const COMING_SOON_MENUS = [
@@ -123,6 +128,25 @@ export function AdminSidebar({ userEmail, userInitial }: AdminSidebarProps) {
         <SectionLabel label="Curation" />
         <div className="space-y-0.5">
           {CURATION_MENUS.map(({ label, icon: Icon, href }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                isActive(href)
+                  ? "bg-brand text-brand-foreground"
+                  : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+              }`}
+            >
+              <Icon className="size-4 shrink-0" />
+              {label}
+            </Link>
+          ))}
+        </div>
+
+        {/* MODERATION 섹션 */}
+        <SectionLabel label="Moderation" />
+        <div className="space-y-0.5">
+          {MODERATION_MENUS.map(({ label, icon: Icon, href }) => (
             <Link
               key={href}
               href={href}

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -33,6 +33,7 @@ const MapPreview = dynamic(
   { ssr: false, loading: () => <div className="h-[260px] rounded-md bg-muted/50 animate-pulse" /> },
 );
 import type { PostStatus } from "@prisma/client";
+import { STATUS_LABELS, STATUS_COLORS } from "../_constants";
 import { computeTopicEffectiveColors, type EffectiveColorInfo } from "@/lib/post-labels";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -584,6 +585,11 @@ export function PostForm({
             <h1 className="text-base font-semibold">
               {isEdit ? "포스트 수정" : "포스트 작성"}
             </h1>
+            {isEdit && (
+              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[status]}`}>
+                {STATUS_LABELS[status]}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-2">
             {!isEmbedded && isEdit && initialData?.slug && (
@@ -608,7 +614,7 @@ export function PostForm({
 
             {!isEmbedded && isEdit && status === "PUBLISHED" && (
               <Button variant="outline" size="sm" disabled={isPending} onClick={() => handleSubmit("DRAFT")}>
-                임시저장으로 변경
+                비공개로 변경
               </Button>
             )}
 

--- a/src/app/admin/posts/_constants.ts
+++ b/src/app/admin/posts/_constants.ts
@@ -1,7 +1,7 @@
 import type { PostStatus } from "@prisma/client";
 
 export const STATUS_LABELS: Record<PostStatus, string> = {
-  DRAFT: "임시저장",
+  DRAFT: "비공개",
   PUBLISHED: "발행됨",
 };
 

--- a/src/app/admin/recreeshots/_actions/recreeshot-actions.ts
+++ b/src/app/admin/recreeshots/_actions/recreeshot-actions.ts
@@ -34,7 +34,7 @@ export async function dismissReport(reportId: string) {
   revalidate();
 }
 
-// 신고 처리 — 리크리샷 숨김 처리
+// 신고 처리 — 리크리샷 REPORT_HIDDEN 처리 (신고로 인한 숨김)
 export async function resolveReport(reportId: string) {
   const report = await prisma.report.findUnique({
     where: { id: reportId },
@@ -48,7 +48,28 @@ export async function resolveReport(reportId: string) {
     if (report?.reCreeshotId) {
       await tx.reCreeshot.update({
         where: { id: report.reCreeshotId },
-        data: { status: "HIDDEN" },
+        data: { status: "REPORT_HIDDEN" },
+      });
+    }
+  });
+  revalidate();
+}
+
+// 신고 되돌리기 — PENDING으로 복원, 리크리샷 REPORTED로 복원
+export async function restoreReport(reportId: string) {
+  const report = await prisma.report.findUnique({
+    where: { id: reportId },
+    select: { reCreeshotId: true },
+  });
+  await prisma.$transaction(async (tx) => {
+    await tx.report.update({
+      where: { id: reportId },
+      data: { status: "PENDING", resolvedAt: null },
+    });
+    if (report?.reCreeshotId) {
+      await tx.reCreeshot.update({
+        where: { id: report.reCreeshotId },
+        data: { status: "REPORTED" },
       });
     }
   });

--- a/src/app/admin/recreeshots/_actions/recreeshot-actions.ts
+++ b/src/app/admin/recreeshots/_actions/recreeshot-actions.ts
@@ -12,3 +12,45 @@ export async function setRecreeshotStatus(id: string, status: ReCreeshotStatus) 
   await prisma.reCreeshot.update({ where: { id }, data: { status } });
   revalidate();
 }
+
+// 신고 기각 — 리크리샷 status를 ACTIVE로 복원
+export async function dismissReport(reportId: string) {
+  const report = await prisma.report.findUnique({
+    where: { id: reportId },
+    select: { reCreeshotId: true },
+  });
+  await prisma.$transaction(async (tx) => {
+    await tx.report.update({
+      where: { id: reportId },
+      data: { status: "DISMISSED", resolvedAt: new Date() },
+    });
+    if (report?.reCreeshotId) {
+      await tx.reCreeshot.update({
+        where: { id: report.reCreeshotId },
+        data: { status: "ACTIVE" },
+      });
+    }
+  });
+  revalidate();
+}
+
+// 신고 처리 — 리크리샷 숨김 처리
+export async function resolveReport(reportId: string) {
+  const report = await prisma.report.findUnique({
+    where: { id: reportId },
+    select: { reCreeshotId: true },
+  });
+  await prisma.$transaction(async (tx) => {
+    await tx.report.update({
+      where: { id: reportId },
+      data: { status: "RESOLVED", resolvedAt: new Date() },
+    });
+    if (report?.reCreeshotId) {
+      await tx.reCreeshot.update({
+        where: { id: report.reCreeshotId },
+        data: { status: "HIDDEN" },
+      });
+    }
+  });
+  revalidate();
+}

--- a/src/app/admin/recreeshots/_components/RecreeshotTable.tsx
+++ b/src/app/admin/recreeshots/_components/RecreeshotTable.tsx
@@ -3,7 +3,6 @@
 import { useState, useTransition } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { EyeOff, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/utils";
 import { setRecreeshotStatus } from "../_actions/recreeshot-actions";
@@ -23,22 +22,23 @@ export type RecreeshotRow = {
 };
 
 const STATUS_BADGE: Record<ReCreeshotStatus, string> = {
-  ACTIVE: "bg-green-100 text-green-700",
-  REPORTED: "bg-orange-100 text-orange-700",
-  HIDDEN: "bg-zinc-100 text-zinc-500",
-  DELETED: "bg-red-100 text-red-600",
+  ACTIVE:       "bg-green-100 text-green-700",
+  REPORTED:     "bg-orange-100 text-orange-700",
+  HIDDEN:       "bg-zinc-100 text-zinc-500",
+  REPORT_HIDDEN:"bg-red-100 text-red-600",
+  DELETED:      "bg-zinc-100 text-zinc-400",
 };
 
 const STATUS_LABEL: Record<ReCreeshotStatus, string> = {
-  ACTIVE: "활성",
-  REPORTED: "신고됨",
-  HIDDEN: "숨김",
-  DELETED: "삭제됨",
+  ACTIVE:       "공개",
+  REPORTED:     "신고됨",
+  HIDDEN:       "숨김",
+  REPORT_HIDDEN:"신고로 숨김",
+  DELETED:      "삭제됨",
 };
 
-
 export function RecreeshotTable({ rows }: { rows: RecreeshotRow[] }) {
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
   const [localRows, setLocalRows] = useState(rows);
 
   function optimisticUpdate(id: string, status: ReCreeshotStatus) {
@@ -62,14 +62,14 @@ export function RecreeshotTable({ rows }: { rows: RecreeshotRow[] }) {
           <thead className="bg-zinc-50 border-b border-zinc-100">
             <tr>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground w-[72px]">이미지</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상태</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">사용자</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">장소</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">포스트</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">라벨</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap w-[90px]">점수</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">등록일</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상태</th>
-              <th className="w-20 px-2 py-3" />
+              <th className="w-28 px-2 py-3" />
             </tr>
           </thead>
           <tbody>
@@ -89,21 +89,23 @@ export function RecreeshotTable({ rows }: { rows: RecreeshotRow[] }) {
                 <td className="px-4 py-3">
                   <Link href={`/explore/hall/${row.id}`} target="_blank" rel="noopener noreferrer">
                     <div className="relative w-10 aspect-[4/5] rounded overflow-hidden bg-muted hover:opacity-80 transition-opacity">
-                      <Image
-                        src={row.imageUrl}
-                        alt="recreeshot"
-                        fill
-                        className="object-cover"
-                        sizes="40px"
-                      />
+                      <Image src={row.imageUrl} alt="recreeshot" fill className="object-cover" sizes="40px" />
                     </div>
                   </Link>
                 </td>
 
-                {/* 사용자 */}
-                <td className="px-4 py-3 text-xs text-muted-foreground">
-                  {row.user?.email ?? "—"}
+                {/* 상태 — 앞으로 이동해 한눈에 파악 */}
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${STATUS_BADGE[row.status]}`}>
+                    {STATUS_LABEL[row.status]}
+                  </span>
+                  {row.status === "REPORTED" && (
+                    <p className="text-[10px] text-orange-500 mt-0.5 whitespace-nowrap">신고 처리 탭에서 조치</p>
+                  )}
                 </td>
+
+                {/* 사용자 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground">{row.user?.email ?? "—"}</td>
 
                 {/* 장소 */}
                 <td className="px-4 py-3 min-w-[120px]">
@@ -133,15 +135,12 @@ export function RecreeshotTable({ rows }: { rows: RecreeshotRow[] }) {
                   )}
                 </td>
 
-                {/* 태그 */}
+                {/* 라벨 */}
                 <td className="px-4 py-3 min-w-[120px]">
                   <div className="flex flex-wrap gap-1">
                     {row.labelNames.length > 0 ? (
                       row.labelNames.slice(0, 3).map((name) => (
-                        <span
-                          key={name}
-                          className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded"
-                        >
+                        <span key={name} className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
                           {name}
                         </span>
                       ))
@@ -168,41 +167,31 @@ export function RecreeshotTable({ rows }: { rows: RecreeshotRow[] }) {
                 </td>
 
                 {/* 등록일 */}
-                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
-                  {formatDate(row.createdAt)}
-                </td>
-
-                {/* 상태 */}
-                <td className="px-4 py-3">
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${STATUS_BADGE[row.status]}`}>
-                    {STATUS_LABEL[row.status]}
-                  </span>
-                </td>
+                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">{formatDate(row.createdAt)}</td>
 
                 {/* 액션 */}
-                <td className="px-2 py-3">
-                  <div className="flex items-center justify-end gap-1">
-                    {row.status === "ACTIVE" || row.status === "REPORTED" ? (
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end">
+                    {(row.status === "ACTIVE" || row.status === "REPORTED") && (
                       <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        size="sm"
+                        disabled={isPending}
                         onClick={() => handleHide(row.id)}
-                        title="숨김 처리"
+                        className="text-xs h-7 px-2.5 bg-zinc-200 hover:bg-zinc-300 text-zinc-700 border-0"
                       >
-                        <EyeOff className="size-3.5" />
+                        숨김 처리
                       </Button>
-                    ) : row.status === "HIDDEN" ? (
+                    )}
+                    {(row.status === "HIDDEN" || row.status === "REPORT_HIDDEN") && (
                       <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        size="sm"
+                        disabled={isPending}
                         onClick={() => handleRestore(row.id)}
-                        title="복원"
+                        className="text-xs h-7 px-2.5 bg-green-100 hover:bg-green-200 text-green-700 border-0"
                       >
-                        <RotateCcw className="size-3.5" />
+                        공개 복원
                       </Button>
-                    ) : null}
+                    )}
                   </div>
                 </td>
               </tr>

--- a/src/app/admin/recreeshots/_components/RecreeshotTabs.tsx
+++ b/src/app/admin/recreeshots/_components/RecreeshotTabs.tsx
@@ -1,0 +1,36 @@
+interface Tab {
+  label: string;
+  value: string;
+  count: number;
+  highlight?: boolean;
+}
+
+interface Props {
+  tabs: Tab[];
+  current: string;
+}
+
+export function RecreeshotTabs({ tabs, current }: Props) {
+  return (
+    <div className="flex border-b border-zinc-200">
+      {tabs.map(({ label, value, count, highlight }) => (
+        <a
+          key={value}
+          href={`?status=${value}`}
+          className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5 ${
+            current === value
+              ? "border-zinc-900 text-zinc-900"
+              : "border-transparent text-zinc-400 hover:text-zinc-700"
+          }`}
+        >
+          {label}
+          {count > 0 && (
+            <span className={`text-xs font-normal ${highlight && current !== value ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
+              ({count})
+            </span>
+          )}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/recreeshots/_components/ReportList.tsx
+++ b/src/app/admin/recreeshots/_components/ReportList.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Check, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatDate } from "@/lib/utils";
+import { dismissReport, resolveReport } from "../_actions/recreeshot-actions";
+import type { ReportReason, ReportStatus } from "@prisma/client";
+
+export type ReportRow = {
+  id: string;
+  reason: ReportReason;
+  description: string | null;
+  status: ReportStatus;
+  createdAt: Date;
+  resolvedAt: Date | null;
+  reporter: { email: string } | null;
+  reCreeshot: {
+    id: string;
+    imageUrl: string;
+  } | null;
+};
+
+const REASON_LABEL: Record<ReportReason, string> = {
+  SPAM: "스팸",
+  INAPPROPRIATE: "부적절한 콘텐츠",
+  HARASSMENT: "괴롭힘/욕설",
+  FALSE_INFORMATION: "허위 정보",
+  COPYRIGHT: "저작권 침해",
+  OTHER: "기타",
+};
+
+const STATUS_BADGE: Record<ReportStatus, string> = {
+  PENDING: "bg-orange-100 text-orange-700",
+  DISMISSED: "bg-zinc-100 text-zinc-500",
+  RESOLVED: "bg-green-100 text-green-700",
+};
+
+const STATUS_LABEL: Record<ReportStatus, string> = {
+  PENDING: "미처리",
+  DISMISSED: "기각",
+  RESOLVED: "처리완료",
+};
+
+export function ReportList({ rows }: { rows: ReportRow[] }) {
+  const [, startTransition] = useTransition();
+  const [localRows, setLocalRows] = useState(rows);
+
+  function optimisticUpdate(id: string, status: ReportStatus) {
+    setLocalRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)));
+  }
+
+  function handleDismiss(id: string) {
+    optimisticUpdate(id, "DISMISSED");
+    startTransition(() => dismissReport(id));
+  }
+
+  function handleResolve(id: string) {
+    optimisticUpdate(id, "RESOLVED");
+    startTransition(() => resolveReport(id));
+  }
+
+  return (
+    <div className="mt-4 rounded-xl overflow-hidden shadow-sm bg-white">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50 border-b border-zinc-100">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground w-[72px]">리크리샷</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고자</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고 사유</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상세 내용</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">신고일</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상태</th>
+              <th className="w-24 px-2 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {localRows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-16 text-center text-sm text-muted-foreground">
+                  신고 내역이 없습니다.
+                </td>
+              </tr>
+            )}
+            {localRows.map((row) => (
+              <tr
+                key={row.id}
+                className="border-b border-zinc-100 last:border-b-0 transition-colors hover:bg-zinc-50"
+              >
+                {/* 리크리샷 썸네일 */}
+                <td className="px-4 py-3">
+                  {row.reCreeshot ? (
+                    <Link href={`/explore/hall/${row.reCreeshot.id}`} target="_blank" rel="noopener noreferrer">
+                      <div className="relative w-10 aspect-[4/5] rounded overflow-hidden bg-muted hover:opacity-80 transition-opacity">
+                        <Image
+                          src={row.reCreeshot.imageUrl}
+                          alt="recreeshot"
+                          fill
+                          className="object-cover"
+                          sizes="40px"
+                        />
+                      </div>
+                    </Link>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/40">—</span>
+                  )}
+                </td>
+
+                {/* 신고자 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground">
+                  {row.reporter?.email ?? "—"}
+                </td>
+
+                {/* 신고 사유 */}
+                <td className="px-4 py-3">
+                  <span className="text-xs font-medium bg-muted px-2 py-0.5 rounded">
+                    {REASON_LABEL[row.reason]}
+                  </span>
+                </td>
+
+                {/* 상세 내용 */}
+                <td className="px-4 py-3 max-w-[200px]">
+                  {row.description ? (
+                    <p className="text-xs text-muted-foreground line-clamp-2">{row.description}</p>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/40">—</span>
+                  )}
+                </td>
+
+                {/* 신고일 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
+                  {formatDate(row.createdAt)}
+                </td>
+
+                {/* 상태 */}
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${STATUS_BADGE[row.status]}`}>
+                    {STATUS_LABEL[row.status]}
+                  </span>
+                </td>
+
+                {/* 액션 */}
+                <td className="px-2 py-3">
+                  {row.status === "PENDING" && (
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        onClick={() => handleDismiss(row.id)}
+                        title="기각"
+                      >
+                        <X className="size-3.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-green-600 hover:text-green-700"
+                        onClick={() => handleResolve(row.id)}
+                        title="처리완료 (숨김)"
+                      >
+                        <Check className="size-3.5" />
+                      </Button>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/recreeshots/_components/ReportList.tsx
+++ b/src/app/admin/recreeshots/_components/ReportList.tsx
@@ -3,11 +3,10 @@
 import { useState, useTransition } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Check, X } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/utils";
-import { dismissReport, resolveReport } from "../_actions/recreeshot-actions";
-import type { ReportReason, ReportStatus } from "@prisma/client";
+import { dismissReport, resolveReport, restoreReport } from "../_actions/recreeshot-actions";
+import { REASON_LABEL, REPORT_STATUS_BADGE } from "@/lib/report-constants";
+import type { ReportReason, ReportStatus, ReCreeshotStatus } from "@prisma/client";
 
 export type ReportRow = {
   id: string;
@@ -20,46 +19,67 @@ export type ReportRow = {
   reCreeshot: {
     id: string;
     imageUrl: string;
+    status: ReCreeshotStatus;
   } | null;
 };
 
-const REASON_LABEL: Record<ReportReason, string> = {
-  SPAM: "스팸",
-  INAPPROPRIATE: "부적절한 콘텐츠",
-  HARASSMENT: "괴롭힘/욕설",
-  FALSE_INFORMATION: "허위 정보",
-  COPYRIGHT: "저작권 침해",
-  OTHER: "기타",
+const REPORT_STATUS_LABEL: Record<ReportStatus, string> = {
+  PENDING:   "미처리",
+  DISMISSED: "신고 기각",
+  RESOLVED:  "숨김 처리됨",
 };
 
-const STATUS_BADGE: Record<ReportStatus, string> = {
-  PENDING: "bg-orange-100 text-orange-700",
-  DISMISSED: "bg-zinc-100 text-zinc-500",
-  RESOLVED: "bg-green-100 text-green-700",
+const SHOT_STATUS_BADGE: Record<ReCreeshotStatus, string> = {
+  ACTIVE:       "bg-green-50 text-green-600",
+  REPORTED:     "bg-orange-50 text-orange-600",
+  HIDDEN:       "bg-zinc-100 text-zinc-500",
+  REPORT_HIDDEN:"bg-red-100 text-red-600",
+  DELETED:      "bg-zinc-100 text-zinc-400",
 };
 
-const STATUS_LABEL: Record<ReportStatus, string> = {
-  PENDING: "미처리",
-  DISMISSED: "기각",
-  RESOLVED: "처리완료",
+const SHOT_STATUS_LABEL: Record<ReCreeshotStatus, string> = {
+  ACTIVE:       "공개",
+  REPORTED:     "신고됨",
+  HIDDEN:       "숨김",
+  REPORT_HIDDEN:"신고로 숨김",
+  DELETED:      "삭제됨",
 };
 
 export function ReportList({ rows }: { rows: ReportRow[] }) {
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
   const [localRows, setLocalRows] = useState(rows);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
-  function optimisticUpdate(id: string, status: ReportStatus) {
-    setLocalRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)));
+  function optimisticUpdate(id: string, updates: Partial<ReportRow>) {
+    setLocalRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...updates } : r)));
   }
 
   function handleDismiss(id: string) {
-    optimisticUpdate(id, "DISMISSED");
+    optimisticUpdate(id, { status: "DISMISSED", resolvedAt: new Date() });
     startTransition(() => dismissReport(id));
   }
 
-  function handleResolve(id: string) {
-    optimisticUpdate(id, "RESOLVED");
+  function handleResolveConfirm(id: string) {
+    setConfirmingId(null);
+    optimisticUpdate(id, {
+      status: "RESOLVED",
+      resolvedAt: new Date(),
+      reCreeshot: localRows.find((r) => r.id === id)?.reCreeshot
+        ? { ...localRows.find((r) => r.id === id)!.reCreeshot!, status: "REPORT_HIDDEN" }
+        : null,
+    });
     startTransition(() => resolveReport(id));
+  }
+
+  function handleRestore(id: string) {
+    optimisticUpdate(id, {
+      status: "PENDING",
+      resolvedAt: null,
+      reCreeshot: localRows.find((r) => r.id === id)?.reCreeshot
+        ? { ...localRows.find((r) => r.id === id)!.reCreeshot!, status: "REPORTED" }
+        : null,
+    });
+    startTransition(() => restoreReport(id));
   }
 
   return (
@@ -69,18 +89,20 @@ export function ReportList({ rows }: { rows: ReportRow[] }) {
           <thead className="bg-zinc-50 border-b border-zinc-100">
             <tr>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground w-[72px]">리크리샷</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">콘텐츠 상태</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고자</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고 사유</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">상세 내용</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">신고일</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상태</th>
-              <th className="w-24 px-2 py-3" />
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">처리일</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">처리 상태</th>
+              <th className="px-4 py-3 w-[220px]" />
             </tr>
           </thead>
           <tbody>
             {localRows.length === 0 && (
               <tr>
-                <td colSpan={7} className="px-4 py-16 text-center text-sm text-muted-foreground">
+                <td colSpan={9} className="px-4 py-16 text-center text-sm text-muted-foreground">
                   신고 내역이 없습니다.
                 </td>
               </tr>
@@ -95,13 +117,7 @@ export function ReportList({ rows }: { rows: ReportRow[] }) {
                   {row.reCreeshot ? (
                     <Link href={`/explore/hall/${row.reCreeshot.id}`} target="_blank" rel="noopener noreferrer">
                       <div className="relative w-10 aspect-[4/5] rounded overflow-hidden bg-muted hover:opacity-80 transition-opacity">
-                        <Image
-                          src={row.reCreeshot.imageUrl}
-                          alt="recreeshot"
-                          fill
-                          className="object-cover"
-                          sizes="40px"
-                        />
+                        <Image src={row.reCreeshot.imageUrl} alt="recreeshot" fill className="object-cover" sizes="40px" />
                       </div>
                     </Link>
                   ) : (
@@ -109,10 +125,19 @@ export function ReportList({ rows }: { rows: ReportRow[] }) {
                   )}
                 </td>
 
-                {/* 신고자 */}
-                <td className="px-4 py-3 text-xs text-muted-foreground">
-                  {row.reporter?.email ?? "—"}
+                {/* 콘텐츠 현재 상태 */}
+                <td className="px-4 py-3">
+                  {row.reCreeshot ? (
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${SHOT_STATUS_BADGE[row.reCreeshot.status]}`}>
+                      {SHOT_STATUS_LABEL[row.reCreeshot.status]}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/40">—</span>
+                  )}
                 </td>
+
+                {/* 신고자 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground">{row.reporter?.email ?? "—"}</td>
 
                 {/* 신고 사유 */}
                 <td className="px-4 py-3">
@@ -122,48 +147,81 @@ export function ReportList({ rows }: { rows: ReportRow[] }) {
                 </td>
 
                 {/* 상세 내용 */}
-                <td className="px-4 py-3 max-w-[200px]">
-                  {row.description ? (
-                    <p className="text-xs text-muted-foreground line-clamp-2">{row.description}</p>
-                  ) : (
-                    <span className="text-xs text-muted-foreground/40">—</span>
-                  )}
+                <td className="px-4 py-3 max-w-[180px]">
+                  {row.description
+                    ? <p className="text-xs text-muted-foreground line-clamp-2">{row.description}</p>
+                    : <span className="text-xs text-muted-foreground/40">—</span>
+                  }
                 </td>
 
                 {/* 신고일 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">{formatDate(row.createdAt)}</td>
+
+                {/* 처리일 */}
                 <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
-                  {formatDate(row.createdAt)}
+                  {row.resolvedAt ? formatDate(row.resolvedAt) : <span className="text-muted-foreground/40">—</span>}
                 </td>
 
-                {/* 상태 */}
+                {/* 처리 상태 */}
                 <td className="px-4 py-3">
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${STATUS_BADGE[row.status]}`}>
-                    {STATUS_LABEL[row.status]}
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${REPORT_STATUS_BADGE[row.status]}`}>
+                    {REPORT_STATUS_LABEL[row.status]}
                   </span>
                 </td>
 
                 {/* 액션 */}
-                <td className="px-2 py-3">
+                <td className="px-4 py-3">
                   {row.status === "PENDING" && (
-                    <div className="flex items-center justify-end gap-1">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                        onClick={() => handleDismiss(row.id)}
-                        title="기각"
+                    confirmingId === row.id ? (
+                      <div className="flex items-center justify-end gap-1.5">
+                        <span className="text-xs text-zinc-500 mr-1">콘텐츠가 숨김 처리됩니다.</span>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingId(null)}
+                          className="px-2.5 py-1.5 rounded-md text-xs font-medium text-zinc-500 bg-zinc-100 hover:bg-zinc-200 transition-colors"
+                        >
+                          취소
+                        </button>
+                        <button
+                          type="button"
+                          disabled={isPending}
+                          onClick={() => handleResolveConfirm(row.id)}
+                          className="px-2.5 py-1.5 rounded-md text-xs font-medium text-white bg-red-500 hover:bg-red-600 transition-colors disabled:opacity-50"
+                        >
+                          숨김 확인
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex items-center justify-end gap-1.5">
+                        <button
+                          type="button"
+                          disabled={isPending}
+                          onClick={() => handleDismiss(row.id)}
+                          className="px-3 py-1.5 rounded-md text-xs font-medium text-zinc-500 bg-zinc-100 hover:bg-zinc-200 transition-colors disabled:opacity-50"
+                        >
+                          신고 기각
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingId(row.id)}
+                          className="px-3 py-1.5 rounded-md text-xs font-medium text-white bg-red-500 hover:bg-red-600 transition-colors"
+                        >
+                          숨김 처리
+                        </button>
+                      </div>
+                    )
+                  )}
+                  {(row.status === "DISMISSED" || row.status === "RESOLVED") && (
+                    <div className="flex items-center justify-end">
+                      <button
+                        type="button"
+                        disabled={isPending}
+                        onClick={() => handleRestore(row.id)}
+                        className="px-2.5 py-1.5 rounded-md text-xs font-medium text-zinc-500 bg-zinc-100 hover:bg-zinc-200 transition-colors disabled:opacity-50"
+                        title={row.status === "RESOLVED" ? "미처리로 되돌리기 (콘텐츠 공개 복원)" : "미처리로 되돌리기"}
                       >
-                        <X className="size-3.5" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8 text-green-600 hover:text-green-700"
-                        onClick={() => handleResolve(row.id)}
-                        title="처리완료 (숨김)"
-                      >
-                        <Check className="size-3.5" />
-                      </Button>
+                        미처리로 되돌리기
+                      </button>
                     </div>
                   )}
                 </td>

--- a/src/app/admin/recreeshots/page.tsx
+++ b/src/app/admin/recreeshots/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { RecreeshotTable, type RecreeshotRow } from "./_components/RecreeshotTable";
+import { ReportList, type ReportRow } from "./_components/ReportList";
 import type { ReCreeshotStatus } from "@prisma/client";
 
 const STATUS_TABS = [
@@ -8,6 +9,7 @@ const STATUS_TABS = [
   { label: "활성", value: "ACTIVE" },
   { label: "신고됨", value: "REPORTED" },
   { label: "숨김", value: "HIDDEN" },
+  { label: "신고 내역", value: "reports" },
 ] as const;
 
 export default async function AdminRecreeshotsPage({
@@ -17,12 +19,96 @@ export default async function AdminRecreeshotsPage({
 }) {
   const { status = "all" } = await searchParams;
 
+  // 신고 내역 탭
+  if (status === "reports") {
+    const reports = await prisma.report.findMany({
+      where: { reCreeshotId: { not: null } },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+      select: {
+        id: true,
+        reason: true,
+        description: true,
+        status: true,
+        createdAt: true,
+        resolvedAt: true,
+        reporter: { select: { email: true } },
+        reCreeshot: { select: { id: true, imageUrl: true } },
+      },
+    });
+
+    const [totalCounts, pendingCount] = await Promise.all([
+      prisma.reCreeshot.groupBy({ by: ["status"], _count: true }),
+      prisma.report.count({ where: { reCreeshotId: { not: null }, status: "PENDING" } }),
+    ]);
+
+    const countMap = new Map(totalCounts.map((c) => [c.status, c._count]));
+    const totalActive = countMap.get("ACTIVE") ?? 0;
+    const totalReported = countMap.get("REPORTED") ?? 0;
+    const totalHidden = countMap.get("HIDDEN") ?? 0;
+    const totalAll = totalActive + totalReported + totalHidden;
+
+    const tabCountMap: Record<string, number> = {
+      all: totalAll,
+      ACTIVE: totalActive,
+      REPORTED: totalReported,
+      HIDDEN: totalHidden,
+      reports: pendingCount,
+    };
+
+    const rows: ReportRow[] = reports.map((r) => ({
+      id: r.id,
+      reason: r.reason,
+      description: r.description,
+      status: r.status,
+      createdAt: r.createdAt,
+      resolvedAt: r.resolvedAt,
+      reporter: r.reporter,
+      reCreeshot: r.reCreeshot,
+    }));
+
+    return (
+      <div className="p-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold">recreeshot 관리</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            사용자가 올린 리크리샷을 검토하고 관리합니다.
+          </p>
+        </div>
+
+        <div className="flex border-b border-zinc-200">
+          {STATUS_TABS.map(({ label, value }) => (
+            <Link
+              key={value}
+              href={`?status=${value}`}
+              className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5 ${
+                status === value
+                  ? "border-zinc-900 text-zinc-900"
+                  : "border-transparent text-zinc-400 hover:text-zinc-700"
+              }`}
+            >
+              {label}
+              {tabCountMap[value] > 0 && (
+                <span className={`text-xs font-normal ${value === "reports" && status !== "reports" ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
+                  ({tabCountMap[value]})
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+
+        <ReportList rows={rows} />
+      </div>
+    );
+  }
+
+  // 기존 리크리샷 목록 탭
   const where =
     status === "all"
       ? { status: { not: "DELETED" as ReCreeshotStatus } }
       : { status: status as ReCreeshotStatus };
 
-  const [recreeshots, totalCounts] = await Promise.all([
+  const [recreeshots, totalCounts, pendingReportCount] = await Promise.all([
     prisma.reCreeshot.findMany({
       where,
       orderBy: { createdAt: "desc" },
@@ -49,9 +135,9 @@ export default async function AdminRecreeshotsPage({
       by: ["status"],
       _count: true,
     }),
+    prisma.report.count({ where: { reCreeshotId: { not: null }, status: "PENDING" } }),
   ]);
 
-  // linkedPostId로 Post 조회 (Prisma relation 없으므로 별도 쿼리)
   const linkedPostIds = recreeshots
     .map((r) => r.linkedPostId)
     .filter((id): id is string => id !== null);
@@ -77,6 +163,7 @@ export default async function AdminRecreeshotsPage({
     ACTIVE: totalActive,
     REPORTED: totalReported,
     HIDDEN: totalHidden,
+    reports: pendingReportCount,
   };
 
   const rows: RecreeshotRow[] = recreeshots.map((r) => ({
@@ -97,7 +184,6 @@ export default async function AdminRecreeshotsPage({
 
   return (
     <div className="p-8">
-      {/* 헤더 */}
       <div className="mb-6">
         <h1 className="text-2xl font-bold">recreeshot 관리</h1>
         <p className="text-sm text-muted-foreground mt-1">
@@ -105,7 +191,6 @@ export default async function AdminRecreeshotsPage({
         </p>
       </div>
 
-      {/* 상태 필터 탭 */}
       <div className="flex border-b border-zinc-200">
         {STATUS_TABS.map(({ label, value }) => (
           <Link
@@ -118,9 +203,11 @@ export default async function AdminRecreeshotsPage({
             }`}
           >
             {label}
-            <span className="text-xs text-muted-foreground font-normal">
-              ({tabCountMap[value] ?? 0})
-            </span>
+            {tabCountMap[value] > 0 && (
+              <span className={`text-xs font-normal ${value === "reports" && status !== "reports" ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
+                ({tabCountMap[value]})
+              </span>
+            )}
           </Link>
         ))}
       </div>

--- a/src/app/admin/recreeshots/page.tsx
+++ b/src/app/admin/recreeshots/page.tsx
@@ -1,15 +1,17 @@
-import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { RecreeshotTable, type RecreeshotRow } from "./_components/RecreeshotTable";
 import { ReportList, type ReportRow } from "./_components/ReportList";
+import { RecreeshotTabs } from "./_components/RecreeshotTabs";
 import type { ReCreeshotStatus } from "@prisma/client";
 
+export const dynamic = "force-dynamic";
+
+// 탭: 전체 / 활성 / 숨김(HIDDEN+REPORT_HIDDEN) / 신고 처리
 const STATUS_TABS = [
-  { label: "전체", value: "all" },
-  { label: "활성", value: "ACTIVE" },
-  { label: "신고됨", value: "REPORTED" },
-  { label: "숨김", value: "HIDDEN" },
-  { label: "신고 내역", value: "reports" },
+  { label: "전체",    value: "all" },
+  { label: "활성",    value: "ACTIVE" },
+  { label: "숨김",    value: "hidden" },
+  { label: "신고 처리", value: "reports" },
 ] as const;
 
 export default async function AdminRecreeshotsPage({
@@ -19,11 +21,49 @@ export default async function AdminRecreeshotsPage({
 }) {
   const { status = "all" } = await searchParams;
 
-  // 신고 내역 탭
+  const [totalCounts, pendingReportCount] = await Promise.all([
+    prisma.reCreeshot.groupBy({ by: ["status"], _count: true }),
+    prisma.report.count({ where: { reCreeshotId: { not: null }, status: "PENDING" } }),
+  ]);
+
+  const countMap = new Map(totalCounts.map((c) => [c.status, c._count]));
+  const totalActive       = countMap.get("ACTIVE") ?? 0;
+  const totalReported     = countMap.get("REPORTED") ?? 0;
+  const totalHidden       = countMap.get("HIDDEN") ?? 0;
+  const totalReportHidden = countMap.get("REPORT_HIDDEN") ?? 0;
+  const totalAll          = totalActive + totalReported + totalHidden + totalReportHidden;
+
+  const tabCountMap: Record<string, number> = {
+    all:     totalAll,
+    ACTIVE:  totalActive,
+    hidden:  totalHidden + totalReportHidden,
+    reports: pendingReportCount,
+  };
+
+  const tabs = STATUS_TABS.map(({ label, value }) => ({
+    label,
+    value,
+    count: tabCountMap[value] ?? 0,
+    highlight: value === "reports",
+  }));
+
+  const header = (
+    <div className="p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">리크리샷 관리</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          사용자가 올린 리크리샷을 검토하고 관리합니다.
+        </p>
+      </div>
+      <RecreeshotTabs tabs={tabs} current={status} />
+    </div>
+  );
+
+  // 신고 처리 탭
   if (status === "reports") {
     const reports = await prisma.report.findMany({
       where: { reCreeshotId: { not: null } },
-      orderBy: { createdAt: "desc" },
+      orderBy: [{ status: "asc" }, { createdAt: "desc" }], // 미처리 먼저
       take: 100,
       select: {
         id: true,
@@ -33,28 +73,9 @@ export default async function AdminRecreeshotsPage({
         createdAt: true,
         resolvedAt: true,
         reporter: { select: { email: true } },
-        reCreeshot: { select: { id: true, imageUrl: true } },
+        reCreeshot: { select: { id: true, imageUrl: true, status: true } },
       },
     });
-
-    const [totalCounts, pendingCount] = await Promise.all([
-      prisma.reCreeshot.groupBy({ by: ["status"], _count: true }),
-      prisma.report.count({ where: { reCreeshotId: { not: null }, status: "PENDING" } }),
-    ]);
-
-    const countMap = new Map(totalCounts.map((c) => [c.status, c._count]));
-    const totalActive = countMap.get("ACTIVE") ?? 0;
-    const totalReported = countMap.get("REPORTED") ?? 0;
-    const totalHidden = countMap.get("HIDDEN") ?? 0;
-    const totalAll = totalActive + totalReported + totalHidden;
-
-    const tabCountMap: Record<string, number> = {
-      all: totalAll,
-      ACTIVE: totalActive,
-      REPORTED: totalReported,
-      HIDDEN: totalHidden,
-      reports: pendingCount,
-    };
 
     const rows: ReportRow[] = reports.map((r) => ({
       id: r.id,
@@ -68,103 +89,61 @@ export default async function AdminRecreeshotsPage({
     }));
 
     return (
-      <div className="p-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold">recreeshot 관리</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            사용자가 올린 리크리샷을 검토하고 관리합니다.
-          </p>
+      <div>
+        {header}
+        <div className="px-8 -mt-4">
+          {pendingReportCount > 0 && (
+            <div className="mb-3 inline-flex items-center gap-1.5 bg-orange-50 border border-orange-200 text-orange-700 text-xs font-medium px-3 py-1.5 rounded-lg">
+              미처리 신고 {pendingReportCount}건이 있습니다.
+            </div>
+          )}
+          <ReportList rows={rows} />
         </div>
-
-        <div className="flex border-b border-zinc-200">
-          {STATUS_TABS.map(({ label, value }) => (
-            <Link
-              key={value}
-              href={`?status=${value}`}
-              className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5 ${
-                status === value
-                  ? "border-zinc-900 text-zinc-900"
-                  : "border-transparent text-zinc-400 hover:text-zinc-700"
-              }`}
-            >
-              {label}
-              {tabCountMap[value] > 0 && (
-                <span className={`text-xs font-normal ${value === "reports" && status !== "reports" ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
-                  ({tabCountMap[value]})
-                </span>
-              )}
-            </Link>
-          ))}
-        </div>
-
-        <ReportList rows={rows} />
       </div>
     );
   }
 
-  // 기존 리크리샷 목록 탭
-  const where =
-    status === "all"
-      ? { status: { not: "DELETED" as ReCreeshotStatus } }
-      : { status: status as ReCreeshotStatus };
+  // 콘텐츠 목록 탭 (전체 / 활성 / 숨김)
+  let where: { status: ReCreeshotStatus | { not: ReCreeshotStatus } | { in: ReCreeshotStatus[] } };
+  if (status === "all") {
+    where = { status: { not: "DELETED" } };
+  } else if (status === "hidden") {
+    where = { status: { in: ["HIDDEN", "REPORT_HIDDEN"] } };
+  } else {
+    where = { status: status as ReCreeshotStatus };
+  }
 
-  const [recreeshots, totalCounts, pendingReportCount] = await Promise.all([
-    prisma.reCreeshot.findMany({
-      where,
-      orderBy: { createdAt: "desc" },
-      take: 50,
-      select: {
-        id: true,
-        imageUrl: true,
-        matchScore: true,
-        showBadge: true,
-        status: true,
-        createdAt: true,
-        linkedPostId: true,
-        user: { select: { email: true } },
-        place: { select: { nameKo: true } },
-        reCreeshotTopics: {
-          select: { topic: { select: { nameEn: true } } },
-        },
-        reCreeshotTags: {
-          select: { tag: { select: { name: true } } },
-        },
-      },
-    }),
-    prisma.reCreeshot.groupBy({
-      by: ["status"],
-      _count: true,
-    }),
-    prisma.report.count({ where: { reCreeshotId: { not: null }, status: "PENDING" } }),
-  ]);
+  const recreeshots = await prisma.reCreeshot.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      imageUrl: true,
+      matchScore: true,
+      showBadge: true,
+      status: true,
+      createdAt: true,
+      linkedPostId: true,
+      user: { select: { email: true } },
+      place: { select: { nameKo: true } },
+      reCreeshotTopics: { select: { topic: { select: { nameEn: true } } } },
+      reCreeshotTags: { select: { tag: { select: { name: true } } } },
+    },
+  });
 
   const linkedPostIds = recreeshots
     .map((r) => r.linkedPostId)
     .filter((id): id is string => id !== null);
 
-  const linkedPosts =
-    linkedPostIds.length > 0
-      ? await prisma.post.findMany({
-          where: { id: { in: linkedPostIds } },
-          select: { id: true, titleKo: true },
-        })
-      : [];
+  const linkedPosts = linkedPostIds.length > 0
+    ? await prisma.post.findMany({
+        where: { id: { in: linkedPostIds } },
+        select: { id: true, titleKo: true },
+      })
+    : [];
 
   const postMap = new Map(linkedPosts.map((p) => [p.id, p]));
-
-  const countMap = new Map(totalCounts.map((c) => [c.status, c._count]));
-  const totalActive = countMap.get("ACTIVE") ?? 0;
-  const totalReported = countMap.get("REPORTED") ?? 0;
-  const totalHidden = countMap.get("HIDDEN") ?? 0;
-  const totalAll = totalActive + totalReported + totalHidden;
-
-  const tabCountMap: Record<string, number> = {
-    all: totalAll,
-    ACTIVE: totalActive,
-    REPORTED: totalReported,
-    HIDDEN: totalHidden,
-    reports: pendingReportCount,
-  };
 
   const rows: RecreeshotRow[] = recreeshots.map((r) => ({
     id: r.id,
@@ -183,36 +162,11 @@ export default async function AdminRecreeshotsPage({
   }));
 
   return (
-    <div className="p-8">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">recreeshot 관리</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          사용자가 올린 리크리샷을 검토하고 관리합니다.
-        </p>
+    <div>
+      {header}
+      <div className="px-8 -mt-4">
+        <RecreeshotTable rows={rows} />
       </div>
-
-      <div className="flex border-b border-zinc-200">
-        {STATUS_TABS.map(({ label, value }) => (
-          <Link
-            key={value}
-            href={`?status=${value}`}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5 ${
-              status === value
-                ? "border-zinc-900 text-zinc-900"
-                : "border-transparent text-zinc-400 hover:text-zinc-700"
-            }`}
-          >
-            {label}
-            {tabCountMap[value] > 0 && (
-              <span className={`text-xs font-normal ${value === "reports" && status !== "reports" ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
-                ({tabCountMap[value]})
-              </span>
-            )}
-          </Link>
-        ))}
-      </div>
-
-      <RecreeshotTable rows={rows} />
     </div>
   );
 }

--- a/src/app/admin/reports/_actions/report-actions.ts
+++ b/src/app/admin/reports/_actions/report-actions.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+
+function revalidate() {
+  revalidatePath("/admin/reports");
+}
+
+// 신고 기각
+export async function dismissPostReport(reportId: string) {
+  await prisma.report.update({
+    where: { id: reportId },
+    data: { status: "DISMISSED", resolvedAt: new Date() },
+  });
+  revalidate();
+}
+
+// 신고 처리완료 (포스트는 자동 숨김 없음 — 관리자가 직접 처리)
+export async function resolvePostReport(reportId: string) {
+  await prisma.report.update({
+    where: { id: reportId },
+    data: { status: "RESOLVED", resolvedAt: new Date() },
+  });
+  revalidate();
+}

--- a/src/app/admin/reports/_actions/report-actions.ts
+++ b/src/app/admin/reports/_actions/report-actions.ts
@@ -7,7 +7,7 @@ function revalidate() {
   revalidatePath("/admin/reports");
 }
 
-// 신고 기각
+// 신고 기각 — 포스트 그대로 유지
 export async function dismissPostReport(reportId: string) {
   await prisma.report.update({
     where: { id: reportId },
@@ -16,11 +16,46 @@ export async function dismissPostReport(reportId: string) {
   revalidate();
 }
 
-// 신고 처리완료 (포스트는 자동 숨김 없음 — 관리자가 직접 처리)
+// 신고 처리완료 — 포스트 DRAFT로 변경 (사용자 화면에서 숨김)
 export async function resolvePostReport(reportId: string) {
-  await prisma.report.update({
+  const report = await prisma.report.findUnique({
     where: { id: reportId },
-    data: { status: "RESOLVED", resolvedAt: new Date() },
+    select: { postId: true },
+  });
+  await prisma.$transaction(async (tx) => {
+    await tx.report.update({
+      where: { id: reportId },
+      data: { status: "RESOLVED", resolvedAt: new Date() },
+    });
+    if (report?.postId) {
+      await tx.post.update({
+        where: { id: report.postId },
+        data: { status: "DRAFT" },
+      });
+    }
   });
   revalidate();
+  revalidatePath("/admin/posts");
+}
+
+// 신고 되돌리기 — PENDING으로 복원, 처리완료였으면 포스트도 PUBLISHED로 복원
+export async function restorePostReport(reportId: string) {
+  const report = await prisma.report.findUnique({
+    where: { id: reportId },
+    select: { postId: true, status: true },
+  });
+  await prisma.$transaction(async (tx) => {
+    await tx.report.update({
+      where: { id: reportId },
+      data: { status: "PENDING", resolvedAt: null },
+    });
+    if (report?.status === "RESOLVED" && report.postId) {
+      await tx.post.update({
+        where: { id: report.postId },
+        data: { status: "PUBLISHED" },
+      });
+    }
+  });
+  revalidate();
+  revalidatePath("/admin/posts");
 }

--- a/src/app/admin/reports/_components/PostReportTable.tsx
+++ b/src/app/admin/reports/_components/PostReportTable.tsx
@@ -2,11 +2,10 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
-import { Check, X } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/utils";
-import { dismissPostReport, resolvePostReport } from "../_actions/report-actions";
-import type { ReportReason, ReportStatus } from "@prisma/client";
+import { dismissPostReport, resolvePostReport, restorePostReport } from "../_actions/report-actions";
+import { REASON_LABEL, REPORT_STATUS_BADGE } from "@/lib/report-constants";
+import type { ReportReason, ReportStatus, PostStatus } from "@prisma/client";
 
 export type PostReportRow = {
   id: string;
@@ -15,46 +14,59 @@ export type PostReportRow = {
   status: ReportStatus;
   createdAt: Date;
   reporter: { email: string } | null;
-  post: { id: string; titleKo: string; slug: string } | null;
+  post: { id: string; titleKo: string; slug: string; status: PostStatus } | null;
 };
 
-const REASON_LABEL: Record<ReportReason, string> = {
-  SPAM: "스팸",
-  INAPPROPRIATE: "부적절한 콘텐츠",
-  HARASSMENT: "괴롭힘/욕설",
-  FALSE_INFORMATION: "허위 정보",
-  COPYRIGHT: "저작권 침해",
-  OTHER: "기타",
-};
-
-const STATUS_BADGE: Record<ReportStatus, string> = {
-  PENDING: "bg-orange-100 text-orange-700",
-  DISMISSED: "bg-zinc-100 text-zinc-500",
-  RESOLVED: "bg-green-100 text-green-700",
-};
-
-const STATUS_LABEL: Record<ReportStatus, string> = {
+const REPORT_STATUS_LABEL: Record<ReportStatus, string> = {
   PENDING: "미처리",
-  DISMISSED: "기각",
-  RESOLVED: "처리완료",
+  DISMISSED: "신고 기각",
+  RESOLVED: "비공개 처리됨",
+};
+
+const POST_STATUS_BADGE: Record<PostStatus, string> = {
+  PUBLISHED: "bg-green-50 text-green-600",
+  DRAFT: "bg-zinc-100 text-zinc-500",
+};
+
+const POST_STATUS_LABEL: Record<PostStatus, string> = {
+  PUBLISHED: "공개",
+  DRAFT: "비공개 (숨김)",
 };
 
 export function PostReportTable({ rows }: { rows: PostReportRow[] }) {
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
   const [localRows, setLocalRows] = useState(rows);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
-  function optimisticUpdate(id: string, status: ReportStatus) {
-    setLocalRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)));
+  function optimisticUpdate(id: string, updates: Partial<PostReportRow>) {
+    setLocalRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...updates } : r)));
   }
 
   function handleDismiss(id: string) {
-    optimisticUpdate(id, "DISMISSED");
+    optimisticUpdate(id, { status: "DISMISSED" });
     startTransition(() => dismissPostReport(id));
   }
 
-  function handleResolve(id: string) {
-    optimisticUpdate(id, "RESOLVED");
+  function handleResolveConfirm(id: string) {
+    setConfirmingId(null);
+    optimisticUpdate(id, {
+      status: "RESOLVED",
+      post: localRows.find((r) => r.id === id)?.post
+        ? { ...localRows.find((r) => r.id === id)!.post!, status: "DRAFT" }
+        : null,
+    });
     startTransition(() => resolvePostReport(id));
+  }
+
+  function handleRestore(id: string) {
+    const row = localRows.find((r) => r.id === id);
+    optimisticUpdate(id, {
+      status: "PENDING",
+      post: row?.post && row.status === "RESOLVED"
+        ? { ...row.post, status: "PUBLISHED" }
+        : row?.post ?? null,
+    });
+    startTransition(() => restorePostReport(id));
   }
 
   return (
@@ -64,18 +76,19 @@ export function PostReportTable({ rows }: { rows: PostReportRow[] }) {
           <thead className="bg-zinc-50 border-b border-zinc-100">
             <tr>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">포스트</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">콘텐츠 상태</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고자</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고 사유</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">상세 내용</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">신고일</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상태</th>
-              <th className="w-24 px-2 py-3" />
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고 상태</th>
+              <th className="px-4 py-3 w-[180px]" />
             </tr>
           </thead>
           <tbody>
             {localRows.length === 0 && (
               <tr>
-                <td colSpan={7} className="px-4 py-16 text-center text-sm text-muted-foreground">
+                <td colSpan={8} className="px-4 py-16 text-center text-sm text-muted-foreground">
                   신고 내역이 없습니다.
                 </td>
               </tr>
@@ -112,10 +125,19 @@ export function PostReportTable({ rows }: { rows: PostReportRow[] }) {
                   )}
                 </td>
 
-                {/* 신고자 */}
-                <td className="px-4 py-3 text-xs text-muted-foreground">
-                  {row.reporter?.email ?? "—"}
+                {/* 콘텐츠 현재 상태 */}
+                <td className="px-4 py-3">
+                  {row.post ? (
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${POST_STATUS_BADGE[row.post.status]}`}>
+                      {POST_STATUS_LABEL[row.post.status]}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/40">—</span>
+                  )}
                 </td>
+
+                {/* 신고자 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground">{row.reporter?.email ?? "—"}</td>
 
                 {/* 신고 사유 */}
                 <td className="px-4 py-3">
@@ -125,48 +147,75 @@ export function PostReportTable({ rows }: { rows: PostReportRow[] }) {
                 </td>
 
                 {/* 상세 내용 */}
-                <td className="px-4 py-3 max-w-[200px]">
-                  {row.description ? (
-                    <p className="text-xs text-muted-foreground line-clamp-2">{row.description}</p>
-                  ) : (
-                    <span className="text-xs text-muted-foreground/40">—</span>
-                  )}
+                <td className="px-4 py-3 max-w-[180px]">
+                  {row.description
+                    ? <p className="text-xs text-muted-foreground line-clamp-2">{row.description}</p>
+                    : <span className="text-xs text-muted-foreground/40">—</span>
+                  }
                 </td>
 
                 {/* 신고일 */}
-                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
-                  {formatDate(row.createdAt)}
-                </td>
+                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">{formatDate(row.createdAt)}</td>
 
-                {/* 상태 */}
+                {/* 신고 상태 */}
                 <td className="px-4 py-3">
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${STATUS_BADGE[row.status]}`}>
-                    {STATUS_LABEL[row.status]}
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${REPORT_STATUS_BADGE[row.status]}`}>
+                    {REPORT_STATUS_LABEL[row.status]}
                   </span>
                 </td>
 
                 {/* 액션 */}
-                <td className="px-2 py-3">
+                <td className="px-4 py-3">
                   {row.status === "PENDING" && (
-                    <div className="flex items-center justify-end gap-1">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                        onClick={() => handleDismiss(row.id)}
-                        title="기각"
+                    confirmingId === row.id ? (
+                      <div className="flex items-center justify-end gap-1.5">
+                        <span className="text-xs text-zinc-500 mr-1">포스트가 비공개로 전환됩니다.</span>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingId(null)}
+                          className="px-2.5 py-1.5 rounded-md text-xs font-medium text-zinc-500 bg-zinc-100 hover:bg-zinc-200 transition-colors"
+                        >
+                          취소
+                        </button>
+                        <button
+                          type="button"
+                          disabled={isPending}
+                          onClick={() => handleResolveConfirm(row.id)}
+                          className="px-2.5 py-1.5 rounded-md text-xs font-medium text-white bg-red-500 hover:bg-red-600 transition-colors disabled:opacity-50"
+                        >
+                          확인
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex items-center justify-end gap-1.5">
+                        <button
+                          type="button"
+                          disabled={isPending}
+                          onClick={() => handleDismiss(row.id)}
+                          className="px-3 py-1.5 rounded-md text-xs font-medium text-zinc-500 bg-zinc-100 hover:bg-zinc-200 transition-colors disabled:opacity-50"
+                        >
+                          기각
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingId(row.id)}
+                          className="px-3 py-1.5 rounded-md text-xs font-medium text-white bg-red-500 hover:bg-red-600 transition-colors"
+                        >
+                          숨김 처리
+                        </button>
+                      </div>
+                    )
+                  )}
+                  {(row.status === "DISMISSED" || row.status === "RESOLVED") && (
+                    <div className="flex items-center justify-end">
+                      <button
+                        type="button"
+                        disabled={isPending}
+                        onClick={() => handleRestore(row.id)}
+                        className="px-2.5 py-1.5 rounded-md text-xs font-medium text-zinc-500 bg-zinc-100 hover:bg-zinc-200 transition-colors disabled:opacity-50"
                       >
-                        <X className="size-3.5" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8 text-green-600 hover:text-green-700"
-                        onClick={() => handleResolve(row.id)}
-                        title="처리완료"
-                      >
-                        <Check className="size-3.5" />
-                      </Button>
+                        {row.status === "RESOLVED" ? "미처리로 되돌리기 (공개 복원)" : "미처리로 되돌리기"}
+                      </button>
                     </div>
                   )}
                 </td>

--- a/src/app/admin/reports/_components/PostReportTable.tsx
+++ b/src/app/admin/reports/_components/PostReportTable.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { Check, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatDate } from "@/lib/utils";
+import { dismissPostReport, resolvePostReport } from "../_actions/report-actions";
+import type { ReportReason, ReportStatus } from "@prisma/client";
+
+export type PostReportRow = {
+  id: string;
+  reason: ReportReason;
+  description: string | null;
+  status: ReportStatus;
+  createdAt: Date;
+  reporter: { email: string } | null;
+  post: { id: string; titleKo: string; slug: string } | null;
+};
+
+const REASON_LABEL: Record<ReportReason, string> = {
+  SPAM: "스팸",
+  INAPPROPRIATE: "부적절한 콘텐츠",
+  HARASSMENT: "괴롭힘/욕설",
+  FALSE_INFORMATION: "허위 정보",
+  COPYRIGHT: "저작권 침해",
+  OTHER: "기타",
+};
+
+const STATUS_BADGE: Record<ReportStatus, string> = {
+  PENDING: "bg-orange-100 text-orange-700",
+  DISMISSED: "bg-zinc-100 text-zinc-500",
+  RESOLVED: "bg-green-100 text-green-700",
+};
+
+const STATUS_LABEL: Record<ReportStatus, string> = {
+  PENDING: "미처리",
+  DISMISSED: "기각",
+  RESOLVED: "처리완료",
+};
+
+export function PostReportTable({ rows }: { rows: PostReportRow[] }) {
+  const [, startTransition] = useTransition();
+  const [localRows, setLocalRows] = useState(rows);
+
+  function optimisticUpdate(id: string, status: ReportStatus) {
+    setLocalRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)));
+  }
+
+  function handleDismiss(id: string) {
+    optimisticUpdate(id, "DISMISSED");
+    startTransition(() => dismissPostReport(id));
+  }
+
+  function handleResolve(id: string) {
+    optimisticUpdate(id, "RESOLVED");
+    startTransition(() => resolvePostReport(id));
+  }
+
+  return (
+    <div className="mt-4 rounded-xl overflow-hidden shadow-sm bg-white">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50 border-b border-zinc-100">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">포스트</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고자</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">신고 사유</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상세 내용</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">신고일</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">상태</th>
+              <th className="w-24 px-2 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {localRows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-16 text-center text-sm text-muted-foreground">
+                  신고 내역이 없습니다.
+                </td>
+              </tr>
+            )}
+            {localRows.map((row) => (
+              <tr
+                key={row.id}
+                className="border-b border-zinc-100 last:border-b-0 transition-colors hover:bg-zinc-50"
+              >
+                {/* 포스트 */}
+                <td className="px-4 py-3 min-w-[180px]">
+                  {row.post ? (
+                    <div className="flex flex-col gap-0.5">
+                      <Link
+                        href={`/admin/posts/${row.post.id}/edit`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-blue-600 hover:underline line-clamp-2 max-w-[220px] block"
+                        title={row.post.titleKo}
+                      >
+                        {row.post.titleKo}
+                      </Link>
+                      <Link
+                        href={`/posts/${row.post.slug}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[10px] text-muted-foreground hover:underline"
+                      >
+                        사용자 페이지 보기
+                      </Link>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/40">—</span>
+                  )}
+                </td>
+
+                {/* 신고자 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground">
+                  {row.reporter?.email ?? "—"}
+                </td>
+
+                {/* 신고 사유 */}
+                <td className="px-4 py-3">
+                  <span className="text-xs font-medium bg-muted px-2 py-0.5 rounded">
+                    {REASON_LABEL[row.reason]}
+                  </span>
+                </td>
+
+                {/* 상세 내용 */}
+                <td className="px-4 py-3 max-w-[200px]">
+                  {row.description ? (
+                    <p className="text-xs text-muted-foreground line-clamp-2">{row.description}</p>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/40">—</span>
+                  )}
+                </td>
+
+                {/* 신고일 */}
+                <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
+                  {formatDate(row.createdAt)}
+                </td>
+
+                {/* 상태 */}
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${STATUS_BADGE[row.status]}`}>
+                    {STATUS_LABEL[row.status]}
+                  </span>
+                </td>
+
+                {/* 액션 */}
+                <td className="px-2 py-3">
+                  {row.status === "PENDING" && (
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        onClick={() => handleDismiss(row.id)}
+                        title="기각"
+                      >
+                        <X className="size-3.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-green-600 hover:text-green-700"
+                        onClick={() => handleResolve(row.id)}
+                        title="처리완료"
+                      >
+                        <Check className="size-3.5" />
+                      </Button>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/reports/_components/ReportTabs.tsx
+++ b/src/app/admin/reports/_components/ReportTabs.tsx
@@ -1,0 +1,1 @@
+export { RecreeshotTabs as ReportTabs } from "../../recreeshots/_components/RecreeshotTabs";

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+import { PostReportTable, type PostReportRow } from "./_components/PostReportTable";
+import type { ReportStatus } from "@prisma/client";
+
+const STATUS_TABS = [
+  { label: "미처리", value: "PENDING" },
+  { label: "기각됨", value: "DISMISSED" },
+  { label: "처리완료", value: "RESOLVED" },
+] as const;
+
+export default async function AdminReportsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const { status = "PENDING" } = await searchParams;
+
+  const [reports, counts] = await Promise.all([
+    prisma.report.findMany({
+      where: {
+        postId: { not: null },
+        status: status as ReportStatus,
+      },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+      select: {
+        id: true,
+        reason: true,
+        description: true,
+        status: true,
+        createdAt: true,
+        reporter: { select: { email: true } },
+        post: { select: { id: true, titleKo: true, slug: true } },
+      },
+    }),
+    prisma.report.groupBy({
+      by: ["status"],
+      where: { postId: { not: null } },
+      _count: true,
+    }),
+  ]);
+
+  const countMap = new Map(counts.map((c) => [c.status, c._count]));
+
+  const rows: PostReportRow[] = reports.map((r) => ({
+    id: r.id,
+    reason: r.reason,
+    description: r.description,
+    status: r.status,
+    createdAt: r.createdAt,
+    reporter: r.reporter,
+    post: r.post,
+  }));
+
+  return (
+    <div className="p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">포스트 신고 관리</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          사용자가 신고한 포스트를 검토하고 처리합니다.
+        </p>
+      </div>
+
+      <div className="flex border-b border-zinc-200">
+        {STATUS_TABS.map(({ label, value }) => (
+          <Link
+            key={value}
+            href={`?status=${value}`}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5 ${
+              status === value
+                ? "border-zinc-900 text-zinc-900"
+                : "border-transparent text-zinc-400 hover:text-zinc-700"
+            }`}
+          >
+            {label}
+            {(countMap.get(value as ReportStatus) ?? 0) > 0 && (
+              <span className={`text-xs font-normal ${value === "PENDING" && status !== "PENDING" ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
+                ({countMap.get(value as ReportStatus) ?? 0})
+              </span>
+            )}
+          </Link>
+        ))}
+      </div>
+
+      <PostReportTable rows={rows} />
+    </div>
+  );
+}

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,12 +1,14 @@
-import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { PostReportTable, type PostReportRow } from "./_components/PostReportTable";
+import { ReportTabs } from "./_components/ReportTabs";
 import type { ReportStatus } from "@prisma/client";
 
+export const dynamic = "force-dynamic";
+
 const STATUS_TABS = [
-  { label: "미처리", value: "PENDING" },
-  { label: "기각됨", value: "DISMISSED" },
-  { label: "처리완료", value: "RESOLVED" },
+  { label: "미처리",    value: "PENDING" },
+  { label: "신고 기각", value: "DISMISSED" },
+  { label: "비공개 처리됨", value: "RESOLVED" },
 ] as const;
 
 export default async function AdminReportsPage({
@@ -31,7 +33,7 @@ export default async function AdminReportsPage({
         status: true,
         createdAt: true,
         reporter: { select: { email: true } },
-        post: { select: { id: true, titleKo: true, slug: true } },
+        post: { select: { id: true, titleKo: true, slug: true, status: true } },
       },
     }),
     prisma.report.groupBy({
@@ -42,6 +44,13 @@ export default async function AdminReportsPage({
   ]);
 
   const countMap = new Map(counts.map((c) => [c.status, c._count]));
+
+  const tabs = STATUS_TABS.map(({ label, value }) => ({
+    label,
+    value,
+    count: countMap.get(value as ReportStatus) ?? 0,
+    highlight: value === "PENDING",
+  }));
 
   const rows: PostReportRow[] = reports.map((r) => ({
     id: r.id,
@@ -62,27 +71,12 @@ export default async function AdminReportsPage({
         </p>
       </div>
 
-      <div className="flex border-b border-zinc-200">
-        {STATUS_TABS.map(({ label, value }) => (
-          <Link
-            key={value}
-            href={`?status=${value}`}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5 ${
-              status === value
-                ? "border-zinc-900 text-zinc-900"
-                : "border-transparent text-zinc-400 hover:text-zinc-700"
-            }`}
-          >
-            {label}
-            {(countMap.get(value as ReportStatus) ?? 0) > 0 && (
-              <span className={`text-xs font-normal ${value === "PENDING" && status !== "PENDING" ? "text-orange-500 font-semibold" : "text-muted-foreground"}`}>
-                ({countMap.get(value as ReportStatus) ?? 0})
-              </span>
-            )}
-          </Link>
-        ))}
-      </div>
-
+      <ReportTabs tabs={tabs} current={status} />
+      {status === "PENDING" && (countMap.get("PENDING") ?? 0) > 0 && (
+        <div className="mt-3 inline-flex items-center gap-1.5 bg-orange-50 border border-orange-200 text-orange-700 text-xs font-medium px-3 py-1.5 rounded-lg">
+          미처리 신고 {countMap.get("PENDING")}건이 있습니다.
+        </div>
+      )}
       <PostReportTable rows={rows} />
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,3 +211,10 @@
   padding: 0.1em 0.35em !important;
   color: var(--palette-gray-900) !important;
 }
+
+/* ── Sonner Toast Override ─────────────────────────────────────── */
+[data-sonner-toaster] {
+  --width: 280px !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans, Noto_Sans_KR } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const notoSans = Noto_Sans({
@@ -28,6 +29,16 @@ export default function RootLayout({
     <html lang="ko" suppressHydrationWarning>
       <body className={`${notoSans.variable} ${notoSansKR.variable} font-sans antialiased`} suppressHydrationWarning>
         {children}
+        <Toaster
+          position="bottom-center"
+          icons={{ success: null, error: null, info: null, warning: null, loading: null }}
+          toastOptions={{
+            unstyled: true,
+            classNames: {
+              toast: "bg-black/50 backdrop-blur-sm text-white text-sm font-medium rounded-2xl px-4 py-2.5 shadow-lg text-center max-w-[280px]",
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/src/components/ReportDialog.tsx
+++ b/src/components/ReportDialog.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { createReport } from "@/app/(user)/_actions/report-actions";
+import type { ReportReason } from "@prisma/client";
+
+const REASONS: { value: ReportReason; label: string }[] = [
+  { value: "SPAM", label: "Spam" },
+  { value: "INAPPROPRIATE", label: "Inappropriate content" },
+  { value: "HARASSMENT", label: "Harassment" },
+  { value: "FALSE_INFORMATION", label: "False information" },
+  { value: "COPYRIGHT", label: "Copyright violation" },
+  { value: "OTHER", label: "Other" },
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  postId?: string;
+  reCreeshotId?: string;
+}
+
+export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
+  const [selectedReason, setSelectedReason] = useState<ReportReason | null>(null);
+  const [description, setDescription] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  if (!open) return null;
+
+  function handleClose() {
+    onClose();
+    setSelectedReason(null);
+    setDescription("");
+  }
+
+  function handleSubmit() {
+    if (!selectedReason) return;
+    startTransition(async () => {
+      const result = await createReport({
+        reason: selectedReason!,
+        description: description.trim() || undefined,
+        postId,
+        reCreeshotId,
+      });
+
+      if (result.error === "already_reported") {
+        toast.error("You've already reported this content.");
+      } else if (result.error === "unauthenticated") {
+        toast.error("Please sign in to report content.");
+      } else if (result.error) {
+        toast.error("Failed to submit. Please try again.");
+      } else {
+        toast.success("Report submitted. Thank you.");
+        handleClose();
+      }
+    });
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center px-4 pb-6 sm:pb-0">
+      <div className="absolute inset-0 bg-black/50" onClick={handleClose} />
+      <div className="relative bg-background rounded-2xl w-full max-w-sm p-5 flex flex-col gap-4">
+        <div>
+          <p className="font-semibold text-base">Report</p>
+          <p className="text-sm text-muted-foreground mt-0.5">Why are you reporting this?</p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          {REASONS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setSelectedReason(value)}
+              className={`w-full text-left px-3.5 py-2.5 rounded-xl text-sm font-medium transition-colors border ${
+                selectedReason === value
+                  ? "border-foreground bg-foreground text-background"
+                  : "border-border hover:bg-muted"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {selectedReason && (
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Additional details (optional)"
+            className="w-full resize-none text-sm border border-border rounded-xl px-3.5 py-2.5 focus:outline-none focus:ring-2 focus:ring-foreground/20 placeholder:text-muted-foreground bg-background"
+            rows={3}
+          />
+        )}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex-1 py-2.5 rounded-full text-sm font-medium border border-border"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!selectedReason || isPending}
+            className="flex-1 py-2.5 rounded-full text-sm font-semibold bg-foreground text-background disabled:opacity-40 transition-opacity"
+          >
+            {isPending ? "Submitting..." : "Submit"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReportDialog.tsx
+++ b/src/components/ReportDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { toast } from "sonner";
+import { useState, useTransition, useEffect } from "react";
+import { CheckCircle } from "lucide-react";
 import { createReport } from "@/app/(user)/_actions/report-actions";
 import type { ReportReason } from "@prisma/client";
 
@@ -14,6 +14,8 @@ const REASONS: { value: ReportReason; label: string }[] = [
   { value: "OTHER", label: "Other" },
 ];
 
+type DialogState = "form" | "success" | "already_reported" | "own_content" | "error";
+
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -25,14 +27,25 @@ export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
   const [selectedReason, setSelectedReason] = useState<ReportReason | null>(null);
   const [description, setDescription] = useState("");
   const [isPending, startTransition] = useTransition();
+  const [dialogState, setDialogState] = useState<DialogState>("form");
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedReason(null);
+      setDescription("");
+      setDialogState("form");
+    }
+  }, [open]);
+
+  // 성공 시 1.8초 후 자동 닫기
+  useEffect(() => {
+    if (dialogState === "success") {
+      const timer = setTimeout(() => onClose(), 1800);
+      return () => clearTimeout(timer);
+    }
+  }, [dialogState, onClose]);
 
   if (!open) return null;
-
-  function handleClose() {
-    onClose();
-    setSelectedReason(null);
-    setDescription("");
-  }
 
   function handleSubmit() {
     if (!selectedReason) return;
@@ -44,72 +57,133 @@ export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
         reCreeshotId,
       });
 
-      if (result.error === "already_reported") {
-        toast.error("You've already reported this content.");
-      } else if (result.error === "unauthenticated") {
-        toast.error("Please sign in to report content.");
+      if (result.error === "own_content") {
+        setDialogState("own_content");
+      } else if (result.error === "already_reported") {
+        setDialogState("already_reported");
       } else if (result.error) {
-        toast.error("Failed to submit. Please try again.");
+        setDialogState("error");
       } else {
-        toast.success("Report submitted. Thank you.");
-        handleClose();
+        setDialogState("success");
       }
     });
   }
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center px-4 pb-6 sm:pb-0">
-      <div className="absolute inset-0 bg-black/50" onClick={handleClose} />
+      <div className="absolute inset-0 bg-black/50" onClick={dialogState === "form" ? onClose : undefined} />
       <div className="relative bg-background rounded-2xl w-full max-w-sm p-5 flex flex-col gap-4">
-        <div>
-          <p className="font-semibold text-base">Report</p>
-          <p className="text-sm text-muted-foreground mt-0.5">Why are you reporting this?</p>
-        </div>
 
-        <div className="flex flex-col gap-1.5">
-          {REASONS.map(({ value, label }) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => setSelectedReason(value)}
-              className={`w-full text-left px-3.5 py-2.5 rounded-xl text-sm font-medium transition-colors border ${
-                selectedReason === value
-                  ? "border-foreground bg-foreground text-background"
-                  : "border-border hover:bg-muted"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-
-        {selectedReason && (
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Additional details (optional)"
-            className="w-full resize-none text-sm border border-border rounded-xl px-3.5 py-2.5 focus:outline-none focus:ring-2 focus:ring-foreground/20 placeholder:text-muted-foreground bg-background"
-            rows={3}
-          />
+        {/* Success */}
+        {dialogState === "success" && (
+          <div className="flex flex-col items-center gap-3 py-6">
+            <CheckCircle className="size-10 text-foreground" strokeWidth={1.5} />
+            <p className="font-semibold text-base text-center">Report submitted.</p>
+            <p className="text-sm text-muted-foreground text-center">Thank you. We'll review it shortly.</p>
+          </div>
         )}
 
-        <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={handleClose}
-            className="flex-1 py-2.5 rounded-full text-sm font-medium border border-border"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={!selectedReason || isPending}
-            className="flex-1 py-2.5 rounded-full text-sm font-semibold bg-foreground text-background disabled:opacity-40 transition-opacity"
-          >
-            {isPending ? "Submitting..." : "Submit"}
-          </button>
-        </div>
+        {/* Own content */}
+        {dialogState === "own_content" && (
+          <div className="flex flex-col gap-4">
+            <p className="font-semibold text-base">Report</p>
+            <p className="text-sm text-muted-foreground text-center py-4">You can't report your own content.</p>
+            <button type="button" onClick={onClose} className="w-full py-2.5 rounded-full text-sm font-medium border border-border">
+              Close
+            </button>
+          </div>
+        )}
+
+        {/* Already reported */}
+        {dialogState === "already_reported" && (
+          <div className="flex flex-col gap-4">
+            <p className="font-semibold text-base">Report</p>
+            <p className="text-sm text-muted-foreground text-center py-4">You've already reported this content.</p>
+            <button type="button" onClick={onClose} className="w-full py-2.5 rounded-full text-sm font-medium border border-border">
+              Close
+            </button>
+          </div>
+        )}
+
+        {/* Error */}
+        {dialogState === "error" && (
+          <div className="flex flex-col gap-4">
+            <p className="font-semibold text-base">Report</p>
+            <p className="text-sm text-muted-foreground text-center py-4">Something went wrong. Please try again.</p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 py-2.5 rounded-full text-sm font-medium border border-border"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={() => setDialogState("form")}
+                className="flex-1 py-2.5 rounded-full text-sm font-semibold bg-foreground text-background"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 기본 폼 */}
+        {dialogState === "form" && (
+          <>
+            <div>
+              <p className="font-semibold text-base">Report</p>
+              <p className="text-sm text-muted-foreground mt-0.5">Why are you reporting this?</p>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              {REASONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setSelectedReason(value)}
+                  className={`w-full text-left px-3.5 py-2.5 rounded-xl text-sm font-medium transition-colors border ${
+                    selectedReason === value
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-border hover:bg-muted"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {selectedReason && (
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Additional details (optional)"
+                className="w-full resize-none text-sm border border-border rounded-xl px-3.5 py-2.5 focus:outline-none focus:ring-2 focus:ring-foreground/20 placeholder:text-muted-foreground bg-background"
+                rows={3}
+              />
+            )}
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 py-2.5 rounded-full text-sm font-medium border border-border"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!selectedReason || isPending}
+                className="flex-1 py-2.5 rounded-full text-sm font-semibold bg-foreground text-background disabled:opacity-40 transition-opacity"
+              >
+                {isPending ? "Submitting..." : "Submit"}
+              </button>
+            </div>
+          </>
+        )}
+
       </div>
     </div>
   );

--- a/src/lib/report-constants.ts
+++ b/src/lib/report-constants.ts
@@ -1,0 +1,16 @@
+import type { ReportReason, ReportStatus } from "@prisma/client";
+
+export const REASON_LABEL: Record<ReportReason, string> = {
+  SPAM: "스팸",
+  INAPPROPRIATE: "부적절한 콘텐츠",
+  HARASSMENT: "괴롭힘/욕설",
+  FALSE_INFORMATION: "허위 정보",
+  COPYRIGHT: "저작권 침해",
+  OTHER: "기타",
+};
+
+export const REPORT_STATUS_BADGE: Record<ReportStatus, string> = {
+  PENDING:   "bg-orange-100 text-orange-700",
+  DISMISSED: "bg-zinc-100 text-zinc-500",
+  RESOLVED:  "bg-red-100 text-red-600",
+};


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->
포스트 및 리크리샷 신고 기능 추가
관리자 페이지에서 숨김 처리 및 기각 가능하게


## 변경 사항
  - 비로그인 차단 (UI + 서버)
  - 본인 콘텐츠 신고 차단 (서버)
  - 중복 신고 방지 (PENDING 기준)
  - 신고 다이얼로그 상태 (성공/이미신고/본인콘텐츠/에러)
  - HIDDEN/REPORT_HIDDEN 상세 페이지 접근 차단
  - 탐색 목록은 ACTIVE만 노출
  - 관리자 처리 전체 플로우 (기각/숨김/되돌리기)
  - 관리자 UI 상태 구분 (숨김 vs 신고로 숨김)
  -
## 스크린샷
<!-- UI 변경이 있으면 첨부. 없으면 삭제 -->
<img width="1140" height="338" alt="Screenshot 2026-03-18 at 8 26 14 PM" src="https://github.com/user-attachments/assets/00f68e82-d765-43c4-b4d0-7bdb412a7d13" />
<img width="1136" height="408" alt="Screenshot 2026-03-18 at 8 25 59 PM" src="https://github.com/user-attachments/assets/63e229f8-c118-44ac-bc65-f9546ca3abdc" />
<img width="431" height="934" alt="Screenshot 2026-03-18 at 8 25 32 PM" src="https://github.com/user-attachments/assets/4fbc11d6-fcb1-487f-8500-3148fd8f6cb5" />
<img width="431" height="934" alt="Screenshot 2026-03-18 at 8 25 26 PM" src="https://github.com/user-attachments/assets/341fb588-0a1e-454c-8600-01069058d688" />
<img width="431" height="934" alt="Screenshot 2026-03-18 at 8 25 22 PM" src="https://github.com/user-attachments/assets/4ee8930d-1b33-4a29-aa38-5eb4d59cdd4f" />
<img width="431" height="934" alt="Screenshot 2026-03-18 at 8 25 13 PM" src="https://github.com/user-attachments/assets/caf005b9-6e42-46b7-9879-d8f75df40267" />
<img width="431" height="934" alt="Screenshot 2026-03-18 at 8 25 09 PM" src="https://github.com/user-attachments/assets/489d18e6-d41c-422a-a52f-23821ad8de97" />


## 리뷰 포인트
<!-- 리뷰어가 특히 봐줬으면 하는 부분. 없으면 삭제 -->
포스트의 상태를 **임시 저장**에서 **비공개**로 이름 바꿈
