### PR TITLE
fix: R2 Presigned URL로 브라우저에서 직접 R2로 업로드

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/s3-request-presigner": "^3.1029.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1027.0
         version: 3.1027.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1029.0
+        version: 3.1029.0
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -276,6 +279,10 @@ packages:
     resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/s3-request-presigner@3.1029.0':
+    resolution: {integrity: sha512-YbHPaha4DYgJWdPorGV5ZSCCqHafGj4GiyqXmXFlCJSsqlOd3xEcemhOZGjrB9epdiVEUtB3DDJXGYYj55ITdQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.16':
     resolution: {integrity: sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==}
     engines: {node: '>=20.0.0'}
@@ -294,6 +301,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.996.6':
     resolution: {integrity: sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.9':
+    resolution: {integrity: sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -5607,6 +5618,17 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
+  '@aws-sdk/s3-request-presigner@3.1029.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.16
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-format-url': 3.972.9
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.16':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.28
@@ -5643,6 +5665,13 @@ snapshots:
       '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.13
       '@smithy/util-endpoints': 3.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':

--- a/src/app/admin/posts/_components/PostImageSection.tsx
+++ b/src/app/admin/posts/_components/PostImageSection.tsx
@@ -22,7 +22,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { focalStyle } from "@/lib/image";
-import { uploadPostImage } from "@/lib/actions/upload-actions";
+import { getPostImagePresignedUrl } from "@/lib/actions/upload-actions";
 import { MAX_POST_IMAGE_SIZE, ALLOWED_IMAGE_ACCEPT } from "@/lib/upload-constants";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -66,9 +66,15 @@ async function uploadImage(
   file: File,
   path: string,
 ): Promise<{ url: string } | { error: string }> {
-  const formData = new FormData();
-  formData.append("file", file);
-  return uploadPostImage(formData, path);
+  const result = await getPostImagePresignedUrl(file.name, file.type, path);
+  if ("error" in result) return result;
+  const res = await fetch(result.presignedUrl, {
+    method: "PUT",
+    body: file,
+    headers: { "Content-Type": file.type },
+  });
+  if (!res.ok) return { error: `업로드 실패 (${res.status})` };
+  return { url: result.cdnUrl };
 }
 
 // ─── 이미지 출처 입력 ─────────────────────────────────────────────────────────
@@ -377,6 +383,8 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
         newBanners.push({ imageType: "BANNER", imageSource: "UPLOAD", url: result.url, isThumbnail: false, sortOrder: newBanners.length });
       });
       replaceImages(newBanners, originalImage);
+    } catch {
+      toast.error("이미지 업로드 중 오류가 발생했습니다.");
     } finally {
       setBannerUploading(false);
     }
@@ -625,9 +633,13 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
                   e.target.value = "";
                   if (!file) return;
                   if (file.size > MAX_POST_IMAGE_SIZE) { toast.error(`${file.name}: 파일 크기가 10MB를 초과합니다.`); return; }
-                  const result = await uploadImage(file, `original/${postId ?? "new"}`);
-                  if ("error" in result) { toast.error(result.error); return; }
-                  setOriginal({ imageType: "ORIGINAL", imageSource: "UPLOAD", url: result.url, linkUrl: null, isThumbnail: false, sortOrder: 0 });
+                  try {
+                    const result = await uploadImage(file, `original/${postId ?? "new"}`);
+                    if ("error" in result) { toast.error(result.error); return; }
+                    setOriginal({ imageType: "ORIGINAL", imageSource: "UPLOAD", url: result.url, linkUrl: null, isThumbnail: false, sortOrder: 0 });
+                  } catch {
+                    toast.error("이미지 업로드 중 오류가 발생했습니다.");
+                  }
                 }}
               />
               <button
@@ -782,11 +794,11 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
             setRecreeUploading(true);
             try {
               const file = new File([blob], `recree-${Date.now()}.jpg`, { type: "image/jpeg" });
-              const formData = new FormData();
-              formData.append("file", file);
-              const result = await uploadPostImage(formData, `recree/${postId ?? "new"}`);
+              const result = await uploadImage(file, `recree/${postId ?? "new"}`);
               if ("error" in result) { toast.error(result.error); return; }
               onRecreePhotoChange(result.url);
+            } catch {
+              toast.error("이미지 업로드 중 오류가 발생했습니다.");
             } finally {
               setRecreeUploading(false);
             }

--- a/src/lib/actions/upload-actions.ts
+++ b/src/lib/actions/upload-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
-import { uploadFile, deleteStorageFiles } from "@/lib/storage";
+import { uploadFile, deleteStorageFiles, getPresignedPutUrl } from "@/lib/storage";
 import { ALLOWED_IMAGE_TYPES, MAX_POST_IMAGE_SIZE, MAX_PLACE_IMAGE_SIZE } from "@/lib/upload-constants";
 
 /** 리크리샷 이미지 R2 업로드 */
@@ -27,6 +27,25 @@ export async function uploadReCreeshotImage(
   } catch (e) {
     console.error("리크리샷 이미지 업로드 오류:", e);
     return { error: "업로드 실패. 다시 시도해주세요." };
+  }
+}
+
+/** 포스트 이미지 브라우저 직접 업로드용 Presigned URL 발급 */
+export async function getPostImagePresignedUrl(
+  filename: string,
+  contentType: string,
+  folderPath: string,
+): Promise<{ presignedUrl: string; cdnUrl: string } | { error: string }> {
+  if (!ALLOWED_IMAGE_TYPES.includes(contentType)) {
+    return { error: `jpg, png, webp 형식만 지원합니다.` };
+  }
+  const ext = filename.split(".").pop() ?? "jpg";
+  const path = `${folderPath}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+  try {
+    return await getPresignedPutUrl("post-images", path, contentType);
+  } catch (e) {
+    console.error("Presigned URL 생성 오류:", e);
+    return { error: "업로드 준비 실패. 다시 시도해주세요." };
   }
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -4,6 +4,7 @@
  */
 
 import { S3Client, PutObjectCommand, DeleteObjectsCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const r2 = new S3Client({
   region: "us-east-1", // R2는 실제 라우팅에 region을 사용하지 않음 — "auto"는 일부 SDK 버전에서 SigV4 오류 발생
@@ -46,6 +47,22 @@ await r2.send(
     }),
   );
   return `${CDN_URL}/${key}`;
+}
+
+/** 브라우저 직접 업로드용 Presigned PUT URL 생성. expiresIn: 초 단위 (기본 300초) */
+export async function getPresignedPutUrl(
+  bucket: string,
+  path: string,
+  contentType: string,
+  expiresIn = 300,
+): Promise<{ presignedUrl: string; cdnUrl: string }> {
+  const key = `${bucket}/${path}`;
+  const presignedUrl = await getSignedUrl(
+    r2,
+    new PutObjectCommand({ Bucket: BUCKET, Key: key, ContentType: contentType }),
+    { expiresIn },
+  );
+  return { presignedUrl, cdnUrl: `${CDN_URL}/${key}` };
 }
 
 /** R2 파일 삭제 (best-effort). 실패해도 에러를 throw하지 않음. */


### PR DESCRIPTION
원인:  Vercel 인프라 자체에 4.5MB 페이로드 제한이 있음.
Next.js bodySizeLimit은 애플리케이션 레벨 설정이라 Vercel 인프라 제한을 못 넘음. 
그래서 5MB 초과 파일이 Vercel에서 차단됨.
토스트 미표시는 server action 호출이 throw되는데 catch 블록이 없어서예요.

변경 사항: 파일을 Server Action으로 보내지 않고, R2 Presigned URL로 브라우저에서 직접 R2에 업로드하도록 변경