### PR TITLE
feature: 태그 라벨 표시 전략 변경 (K-MEDIA 리네이밍 + 카드 라벨 로직 개선 + 관리자 UI 개선

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,6 +155,7 @@ model Tag {
 model TagGroupConfig {
   group        String   @id
   nameEn       String   @default("")
+  displayLabel String?
   colorHex     String   @default("#C6FD09")
   colorHex2    String?
   gradientDir  String   @default("to bottom")

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -12,7 +12,7 @@ import { LabelBadge } from "@/components/LabelBadge";
 import type { PostItem } from "@/lib/post-queries";
 import { ScrapButton } from "./ScrapButton";
 
-const K_SCENE_GROUP = "K_SCENE";
+const K_SCENE_GROUP = "K_MEDIA";
 
 // 슬롯 선택 후 displayLabel 적용 여부를 결정하기 위한 중간 타입
 type LabelSlot = {
@@ -35,7 +35,7 @@ function resolvePostLabels(
     colors: resolveTopicColors(topic),
   }));
 
-  // K_SCENE 태그 슬롯
+  // K_MEDIA 태그 슬롯
   const ksceneSlots: LabelSlot[] = post.postTags
     .filter(({ tag }) => tag.group === K_SCENE_GROUP)
     .map(({ tag }) => {
@@ -43,7 +43,7 @@ function resolvePostLabels(
       return { group: tag.group, name: tag.name, displayLabel: null, colors: resolveTagColors(tag, gc) };
     });
 
-  // non-K_SCENE 태그 슬롯
+  // non-K_MEDIA 태그 슬롯
   const otherSlots: LabelSlot[] = post.postTags
     .filter(({ tag }) => tag.group !== K_SCENE_GROUP)
     .map(({ tag }) => {
@@ -54,8 +54,8 @@ function resolvePostLabels(
   // 슬롯 선택
   let selected: LabelSlot[];
   if (variant === "home") {
-    // 슬롯 1: 토픽 우선, 없으면 non-K_SCENE 태그
-    // 슬롯 2: non-K_SCENE 태그 우선, 없으면 다음 토픽
+    // 슬롯 1: 토픽 우선, 없으면 non-K_MEDIA 태그
+    // 슬롯 2: non-K_MEDIA 태그 우선, 없으면 다음 토픽
     selected = [];
     let topicUsed = 0, otherUsed = 0;
     if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
@@ -63,7 +63,7 @@ function resolvePostLabels(
     if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
     else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
   } else {
-    // list: 토픽 1 + K_SCENE 1 + non-K_SCENE 1, 빈 슬롯은 남은 항목으로 보충 (최대 3개)
+    // list: 토픽 1 + K_MEDIA 1 + non-K_MEDIA 1, 빈 슬롯은 남은 항목으로 보충 (최대 3개)
     selected = [];
     let topicUsed = 0, ksceneUsed = 0, otherUsed = 0;
 
@@ -72,7 +72,7 @@ function resolvePostLabels(
     if (ksceneUsed < ksceneSlots.length) selected.push(ksceneSlots[ksceneUsed++]);
     if (otherUsed < otherSlots.length)  selected.push(otherSlots[otherUsed++]);
 
-    // 2단계: 빈 슬롯 보충 — 남은 항목을 displayOrder 순(토픽→K_SCENE→나머지)으로 채움
+    // 2단계: 빈 슬롯 보충 — 남은 항목을 displayOrder 순(토픽→K_MEDIA→나머지)으로 채움
     if (selected.length < 3) {
       const remaining = [
         ...topicSlots.slice(topicUsed),

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -86,6 +86,10 @@ function resolvePostLabels(
     }
   }
 
+  // 렌더링 순서 보정: 토픽 → K-MEDIA → 나머지 태그
+  const ORDER = (g: string) => g === "TOPIC" ? 0 : g === K_SCENE_GROUP ? 1 : 2;
+  selected.sort((a, b) => ORDER(a.group) - ORDER(b.group));
+
   // displayLabel 적용 조건:
   // 해당 슬롯 외에 다른 group의 슬롯이 함께 표시될 때만 displayLabel 사용.
   // 단독이거나 같은 group끼리만 표시되면 tag.name 그대로 사용.

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -6,7 +6,9 @@ import {
   resolveTagColors,
   labelBackground,
   K_MEDIA_GROUP,
-  labelGroupOrder,
+  selectHomeLabels,
+  selectListLabels,
+  type LabelSlot,
   type TagGroupColorMap,
   type ResolvedLabel,
 } from "@/lib/post-labels";
@@ -14,20 +16,11 @@ import { LabelBadge } from "@/components/LabelBadge";
 import type { PostItem } from "@/lib/post-queries";
 import { ScrapButton } from "./ScrapButton";
 
-// 슬롯 선택 후 displayLabel 적용 여부를 결정하기 위한 중간 타입
-type LabelSlot = {
-  group: string;          // "TOPIC" | 실제 tag group key
-  name: string;           // 항상 원본 이름 (topic.nameEn 또는 tag.name)
-  displayLabel: string | null; // 그룹의 displayLabel (토픽·없는 그룹은 null)
-  colors: Omit<ResolvedLabel, "text">;
-};
-
 function resolvePostLabels(
   post: PostItem,
   tagGroupMap: TagGroupColorMap,
   variant: "home" | "list",
 ): ResolvedLabel[] {
-  // 토픽 슬롯 (displayOrder 오름차순, 쿼리에서 이미 정렬)
   const topicSlots: LabelSlot[] = post.postTopics.map(({ topic }) => ({
     group: "TOPIC",
     name: topic.nameEn,
@@ -35,7 +28,6 @@ function resolvePostLabels(
     colors: resolveTopicColors(topic),
   }));
 
-  // K_MEDIA 태그 슬롯
   const kmediaSlots: LabelSlot[] = post.postTags
     .filter(({ tag }) => tag.group === K_MEDIA_GROUP)
     .map(({ tag }) => {
@@ -43,7 +35,6 @@ function resolvePostLabels(
       return { group: tag.group, name: tag.name, displayLabel: null, colors: resolveTagColors(tag, gc) };
     });
 
-  // non-K_MEDIA 태그 슬롯
   const otherSlots: LabelSlot[] = post.postTags
     .filter(({ tag }) => tag.group !== K_MEDIA_GROUP)
     .map(({ tag }) => {
@@ -51,52 +42,9 @@ function resolvePostLabels(
       return { group: tag.group, name: tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(tag, gc) };
     });
 
-  // 슬롯 선택
-  let selected: LabelSlot[];
-  if (variant === "home") {
-    // 슬롯 1: 토픽 우선, 없으면 non-K_MEDIA 태그
-    // 슬롯 2: non-K_MEDIA 태그 우선, 없으면 다음 토픽
-    selected = [];
-    let topicUsed = 0, otherUsed = 0;
-    if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
-    else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
-    if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
-    else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
-  } else {
-    // list: 토픽 1 + K_MEDIA 1 + non-K_MEDIA 1, 빈 슬롯은 남은 항목으로 보충 (최대 3개)
-    selected = [];
-    let topicUsed = 0, kmediaUsed = 0, otherUsed = 0;
-
-    // 1단계: 각 풀에서 대표 1개씩
-    if (topicUsed < topicSlots.length)  selected.push(topicSlots[topicUsed++]);
-    if (kmediaUsed < kmediaSlots.length) selected.push(kmediaSlots[kmediaUsed++]);
-    if (otherUsed < otherSlots.length)  selected.push(otherSlots[otherUsed++]);
-
-    // 2단계: 빈 슬롯 보충 — 남은 항목을 displayOrder 순(토픽→K_MEDIA→나머지)으로 채움
-    if (selected.length < 3) {
-      const remaining = [
-        ...topicSlots.slice(topicUsed),
-        ...kmediaSlots.slice(kmediaUsed),
-        ...otherSlots.slice(otherUsed),
-      ];
-      for (const slot of remaining) {
-        if (selected.length >= 3) break;
-        selected.push(slot);
-      }
-    }
-  }
-
-  // 렌더링 순서 보정: 토픽 → K-MEDIA → 나머지 태그
-  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
-
-  // displayLabel 적용 조건:
-  // 해당 슬롯 외에 다른 group의 슬롯이 함께 표시될 때만 displayLabel 사용.
-  // 단독이거나 같은 group끼리만 표시되면 tag.name 그대로 사용.
-  return selected.map((slot) => {
-    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
-    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
-    return { text, ...slot.colors };
-  });
+  return variant === "home"
+    ? selectHomeLabels(topicSlots, otherSlots)
+    : selectListLabels(topicSlots, kmediaSlots, otherSlots);
 }
 
 export function PostBadges({

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -12,18 +12,88 @@ import { LabelBadge } from "@/components/LabelBadge";
 import type { PostItem } from "@/lib/post-queries";
 import { ScrapButton } from "./ScrapButton";
 
+const K_SCENE_GROUP = "K_SCENE";
+
+// 슬롯 선택 후 displayLabel 적용 여부를 결정하기 위한 중간 타입
+type LabelSlot = {
+  group: string;          // "TOPIC" | 실제 tag group key
+  name: string;           // 항상 원본 이름 (topic.nameEn 또는 tag.name)
+  displayLabel: string | null; // 그룹의 displayLabel (토픽·없는 그룹은 null)
+  colors: Omit<ResolvedLabel, "text">;
+};
+
 function resolvePostLabels(
   post: PostItem,
   tagGroupMap: TagGroupColorMap,
   variant: "home" | "list",
 ): ResolvedLabel[] {
-  const topics = post.postTopics
-    .map(({ topic }) => ({ text: topic.nameEn, ...resolveTopicColors(topic) }));
-  const tags = post.postTags
-    .map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, tagGroupMap.get(tag.group)) }));
+  // 토픽 슬롯 (displayOrder 오름차순, 쿼리에서 이미 정렬)
+  const topicSlots: LabelSlot[] = post.postTopics.map(({ topic }) => ({
+    group: "TOPIC",
+    name: topic.nameEn,
+    displayLabel: null,
+    colors: resolveTopicColors(topic),
+  }));
 
-  if (variant === "home") return [...topics.slice(0, 1), ...tags.slice(0, 1)];
-  return [...topics.slice(0, 1), ...tags.slice(0, 2)];
+  // K_SCENE 태그 슬롯
+  const ksceneSlots: LabelSlot[] = post.postTags
+    .filter(({ tag }) => tag.group === K_SCENE_GROUP)
+    .map(({ tag }) => {
+      const gc = tagGroupMap.get(tag.group);
+      return { group: tag.group, name: tag.name, displayLabel: null, colors: resolveTagColors(tag, gc) };
+    });
+
+  // non-K_SCENE 태그 슬롯
+  const otherSlots: LabelSlot[] = post.postTags
+    .filter(({ tag }) => tag.group !== K_SCENE_GROUP)
+    .map(({ tag }) => {
+      const gc = tagGroupMap.get(tag.group);
+      return { group: tag.group, name: tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(tag, gc) };
+    });
+
+  // 슬롯 선택
+  let selected: LabelSlot[];
+  if (variant === "home") {
+    // 슬롯 1: 토픽 우선, 없으면 non-K_SCENE 태그
+    // 슬롯 2: non-K_SCENE 태그 우선, 없으면 다음 토픽
+    selected = [];
+    let topicUsed = 0, otherUsed = 0;
+    if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+    else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+    if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+    else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+  } else {
+    // list: 토픽 1 + K_SCENE 1 + non-K_SCENE 1, 빈 슬롯은 남은 항목으로 보충 (최대 3개)
+    selected = [];
+    let topicUsed = 0, ksceneUsed = 0, otherUsed = 0;
+
+    // 1단계: 각 풀에서 대표 1개씩
+    if (topicUsed < topicSlots.length)  selected.push(topicSlots[topicUsed++]);
+    if (ksceneUsed < ksceneSlots.length) selected.push(ksceneSlots[ksceneUsed++]);
+    if (otherUsed < otherSlots.length)  selected.push(otherSlots[otherUsed++]);
+
+    // 2단계: 빈 슬롯 보충 — 남은 항목을 displayOrder 순(토픽→K_SCENE→나머지)으로 채움
+    if (selected.length < 3) {
+      const remaining = [
+        ...topicSlots.slice(topicUsed),
+        ...ksceneSlots.slice(ksceneUsed),
+        ...otherSlots.slice(otherUsed),
+      ];
+      for (const slot of remaining) {
+        if (selected.length >= 3) break;
+        selected.push(slot);
+      }
+    }
+  }
+
+  // displayLabel 적용 조건:
+  // 해당 슬롯 외에 다른 group의 슬롯이 함께 표시될 때만 displayLabel 사용.
+  // 단독이거나 같은 group끼리만 표시되면 tag.name 그대로 사용.
+  return selected.map((slot) => {
+    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
+    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
+    return { text, ...slot.colors };
+  });
 }
 
 export function PostBadges({

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -5,14 +5,14 @@ import {
   resolveTopicColors,
   resolveTagColors,
   labelBackground,
+  K_MEDIA_GROUP,
+  labelGroupOrder,
   type TagGroupColorMap,
   type ResolvedLabel,
 } from "@/lib/post-labels";
 import { LabelBadge } from "@/components/LabelBadge";
 import type { PostItem } from "@/lib/post-queries";
 import { ScrapButton } from "./ScrapButton";
-
-const K_SCENE_GROUP = "K_MEDIA";
 
 // 슬롯 선택 후 displayLabel 적용 여부를 결정하기 위한 중간 타입
 type LabelSlot = {
@@ -36,8 +36,8 @@ function resolvePostLabels(
   }));
 
   // K_MEDIA 태그 슬롯
-  const ksceneSlots: LabelSlot[] = post.postTags
-    .filter(({ tag }) => tag.group === K_SCENE_GROUP)
+  const kmediaSlots: LabelSlot[] = post.postTags
+    .filter(({ tag }) => tag.group === K_MEDIA_GROUP)
     .map(({ tag }) => {
       const gc = tagGroupMap.get(tag.group);
       return { group: tag.group, name: tag.name, displayLabel: null, colors: resolveTagColors(tag, gc) };
@@ -45,7 +45,7 @@ function resolvePostLabels(
 
   // non-K_MEDIA 태그 슬롯
   const otherSlots: LabelSlot[] = post.postTags
-    .filter(({ tag }) => tag.group !== K_SCENE_GROUP)
+    .filter(({ tag }) => tag.group !== K_MEDIA_GROUP)
     .map(({ tag }) => {
       const gc = tagGroupMap.get(tag.group);
       return { group: tag.group, name: tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(tag, gc) };
@@ -65,18 +65,18 @@ function resolvePostLabels(
   } else {
     // list: 토픽 1 + K_MEDIA 1 + non-K_MEDIA 1, 빈 슬롯은 남은 항목으로 보충 (최대 3개)
     selected = [];
-    let topicUsed = 0, ksceneUsed = 0, otherUsed = 0;
+    let topicUsed = 0, kmediaUsed = 0, otherUsed = 0;
 
     // 1단계: 각 풀에서 대표 1개씩
     if (topicUsed < topicSlots.length)  selected.push(topicSlots[topicUsed++]);
-    if (ksceneUsed < ksceneSlots.length) selected.push(ksceneSlots[ksceneUsed++]);
+    if (kmediaUsed < kmediaSlots.length) selected.push(kmediaSlots[kmediaUsed++]);
     if (otherUsed < otherSlots.length)  selected.push(otherSlots[otherUsed++]);
 
     // 2단계: 빈 슬롯 보충 — 남은 항목을 displayOrder 순(토픽→K_MEDIA→나머지)으로 채움
     if (selected.length < 3) {
       const remaining = [
         ...topicSlots.slice(topicUsed),
-        ...ksceneSlots.slice(ksceneUsed),
+        ...kmediaSlots.slice(kmediaUsed),
         ...otherSlots.slice(otherUsed),
       ];
       for (const slot of remaining) {
@@ -87,8 +87,7 @@ function resolvePostLabels(
   }
 
   // 렌더링 순서 보정: 토픽 → K-MEDIA → 나머지 태그
-  const ORDER = (g: string) => g === "TOPIC" ? 0 : g === K_SCENE_GROUP ? 1 : 2;
-  selected.sort((a, b) => ORDER(a.group) - ORDER(b.group));
+  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
 
   // displayLabel 적용 조건:
   // 해당 슬롯 외에 다른 group의 슬롯이 함께 표시될 때만 displayLabel 사용.

--- a/src/app/(user)/explore/hall/[id]/page.tsx
+++ b/src/app/(user)/explore/hall/[id]/page.tsx
@@ -161,7 +161,7 @@ export default async function HallDetailPage({
 
   // 태그 그룹 컬러 맵
   const tagGroups = await prisma.tagGroupConfig.findMany({
-    select: { group: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
+    select: { group: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
   });
   const groupMap: TagGroupColorMap = new Map(tagGroups.map((g) => [g.group, g]));
 

--- a/src/app/(user)/explore/page.tsx
+++ b/src/app/(user)/explore/page.tsx
@@ -134,6 +134,7 @@ export default async function ExplorePage({
       prisma.tagGroupConfig.findMany({
         select: {
           group: true,
+          displayLabel: true,
           colorHex: true,
           colorHex2: true,
           gradientDir: true,

--- a/src/app/(user)/my-map/_components/MapPageClient.tsx
+++ b/src/app/(user)/my-map/_components/MapPageClient.tsx
@@ -25,6 +25,7 @@ type SheetState = "collapsed" | "tab-only" | "peek" | "expanded";
 type TagGroupConfig = {
   group: string;
   nameEn: string;
+  displayLabel: string | null;
   colorHex: string; colorHex2: string | null;
   gradientDir: string; gradientStop: number; textColorHex: string;
 };

--- a/src/app/(user)/my-map/_components/PlaceBottomSheet.tsx
+++ b/src/app/(user)/my-map/_components/PlaceBottomSheet.tsx
@@ -13,6 +13,8 @@ import {
   labelBackground,
   resolveTagColors,
   resolveTopicColors,
+  K_MEDIA_GROUP,
+  labelGroupOrder,
   type TagGroupColorMap,
 } from "@/lib/post-labels";
 import type { MapPlace, MapPost } from "@/lib/map-queries";
@@ -38,15 +40,35 @@ function PostCard({
   isSaved: boolean;
   tagGroupMap: TagGroupColorMap;
 }) {
-  const topicLabels = post.topics.slice(0, 1).map((topic) => {
-    const colors = resolveTopicColors(topic);
-    return { text: topic.nameEn, ...colors };
+  // home variant 슬롯 선택 (resolvePostLabels와 동일한 규칙, 최대 2개)
+  const topicSlots = post.topics.map((topic) => ({
+    group: "TOPIC" as const,
+    name: topic.nameEn,
+    displayLabel: null as string | null,
+    colors: resolveTopicColors(topic),
+  }));
+  const otherSlots = post.tags
+    .filter((tag) => tag.group !== K_MEDIA_GROUP)
+    .map((tag) => {
+      const gc = tagGroupMap.get(tag.group);
+      return { group: tag.group, name: tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(tag, gc) };
+    });
+
+  type Slot = { group: string; name: string; displayLabel: string | null; colors: ReturnType<typeof resolveTopicColors> };
+  const selected: Slot[] = [];
+  let topicUsed = 0, otherUsed = 0;
+  if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+  else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+  if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+  else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+
+  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
+
+  const labels = selected.map((slot) => {
+    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
+    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
+    return { text, ...slot.colors };
   });
-  const tagLabels = post.tags.slice(0, 1).map((tag) => {
-    const colors = resolveTagColors(tag, tagGroupMap.get(tag.group));
-    return { text: tag.name, ...colors };
-  });
-  const labels = [...topicLabels, ...tagLabels];
 
   const cardImageUrl = post.imageUrl ?? post.images[0] ?? null;
 

--- a/src/app/(user)/my-map/_components/PlaceBottomSheet.tsx
+++ b/src/app/(user)/my-map/_components/PlaceBottomSheet.tsx
@@ -14,7 +14,8 @@ import {
   resolveTagColors,
   resolveTopicColors,
   K_MEDIA_GROUP,
-  labelGroupOrder,
+  selectHomeLabels,
+  type LabelSlot,
   type TagGroupColorMap,
 } from "@/lib/post-labels";
 import type { MapPlace, MapPost } from "@/lib/map-queries";
@@ -40,35 +41,19 @@ function PostCard({
   isSaved: boolean;
   tagGroupMap: TagGroupColorMap;
 }) {
-  // home variant 슬롯 선택 (resolvePostLabels와 동일한 규칙, 최대 2개)
-  const topicSlots = post.topics.map((topic) => ({
-    group: "TOPIC" as const,
+  const topicSlots: LabelSlot[] = post.topics.map((topic) => ({
+    group: "TOPIC",
     name: topic.nameEn,
-    displayLabel: null as string | null,
+    displayLabel: null,
     colors: resolveTopicColors(topic),
   }));
-  const otherSlots = post.tags
+  const otherSlots: LabelSlot[] = post.tags
     .filter((tag) => tag.group !== K_MEDIA_GROUP)
     .map((tag) => {
       const gc = tagGroupMap.get(tag.group);
       return { group: tag.group, name: tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(tag, gc) };
     });
-
-  type Slot = { group: string; name: string; displayLabel: string | null; colors: ReturnType<typeof resolveTopicColors> };
-  const selected: Slot[] = [];
-  let topicUsed = 0, otherUsed = 0;
-  if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
-  else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
-  if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
-  else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
-
-  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
-
-  const labels = selected.map((slot) => {
-    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
-    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
-    return { text, ...slot.colors };
-  });
+  const labels = selectHomeLabels(topicSlots, otherSlots);
 
   const cardImageUrl = post.imageUrl ?? post.images[0] ?? null;
 

--- a/src/app/(user)/my-map/page.tsx
+++ b/src/app/(user)/my-map/page.tsx
@@ -30,6 +30,7 @@ export default async function MyTripPage({
         select: {
           group: true,
           nameEn: true,
+          displayLabel: true,
           colorHex: true,
           colorHex2: true,
           gradientDir: true,

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -45,6 +45,10 @@ function resolveBannerLabels(
   if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
   else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
 
+  // 렌더링 순서 보정: 토픽 → K-MEDIA → 나머지 태그
+  const ORDER = (g: string) => g === "TOPIC" ? 0 : g === K_SCENE_GROUP ? 1 : 2;
+  selected.sort((a, b) => ORDER(a.group) - ORDER(b.group));
+
   // displayLabel 조건: 다른 그룹이 함께 표시될 때만 사용
   return selected.map((slot) => {
     const hasOtherGroup = selected.some((s) => s.group !== slot.group);

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -10,7 +10,7 @@ import {
   type ResolvedLabel,
 } from "@/lib/post-labels";
 
-const K_SCENE_GROUP = "K_SCENE";
+const K_SCENE_GROUP = "K_MEDIA";
 
 /** 홈 배너용 라벨 2개 선택 — PostCard home variant와 동일한 규칙 */
 function resolveBannerLabels(
@@ -37,7 +37,7 @@ function resolveBannerLabels(
       return { group: t.tag.group, name: t.tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(t.tag, gc) };
     });
 
-  // 슬롯 선택: 토픽 1 → non-K_SCENE 태그 1 (부족하면 상호 보완)
+  // 슬롯 선택: 토픽 1 → non-K_MEDIA 태그 1 (부족하면 상호 보완)
   const selected: Slot[] = [];
   let topicUsed = 0, otherUsed = 0;
   if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -7,7 +7,51 @@ import {
   resolveTopicColors,
   resolveTagColors,
   type TagGroupColorMap,
+  type ResolvedLabel,
 } from "@/lib/post-labels";
+
+const K_SCENE_GROUP = "K_SCENE";
+
+/** 홈 배너용 라벨 2개 선택 — PostCard home variant와 동일한 규칙 */
+function resolveBannerLabels(
+  postTopics: { isVisible: boolean; displayOrder: number; topic: { nameEn: string; colorHex?: string | null; colorHex2?: string | null; gradientDir?: string; gradientStop?: number; textColorHex?: string | null; parent?: unknown } }[],
+  postTags:   { isVisible: boolean; displayOrder: number; tag:   { name: string; group: string; colorHex?: string | null; colorHex2?: string | null; textColorHex?: string | null } }[],
+  tagGroupMap: TagGroupColorMap,
+): ResolvedLabel[] {
+  type Slot = { group: string; name: string; displayLabel: string | null; colors: Omit<ResolvedLabel, "text"> };
+
+  const topicSlots: Slot[] = postTopics
+    .filter((t) => t.isVisible)
+    .map((t) => ({
+      group: "TOPIC",
+      name: t.topic.nameEn,
+      displayLabel: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      colors: resolveTopicColors(t.topic as any),
+    }));
+
+  const otherSlots: Slot[] = postTags
+    .filter((t) => t.isVisible && t.tag.group !== K_SCENE_GROUP)
+    .map((t) => {
+      const gc = tagGroupMap.get(t.tag.group);
+      return { group: t.tag.group, name: t.tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(t.tag, gc) };
+    });
+
+  // 슬롯 선택: 토픽 1 → non-K_SCENE 태그 1 (부족하면 상호 보완)
+  const selected: Slot[] = [];
+  let topicUsed = 0, otherUsed = 0;
+  if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+  else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+  if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+  else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+
+  // displayLabel 조건: 다른 그룹이 함께 표시될 때만 사용
+  return selected.map((slot) => {
+    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
+    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
+    return { text, ...slot.colors };
+  });
+}
 import { PostCard } from "./_components/PostCard";
 import { SearchBar } from "./_components/SearchBar";
 import { GuideVideoCard } from "./_components/GuideVideoCard";
@@ -122,7 +166,7 @@ export default async function HomePage() {
       orderBy: { order: "asc" },
     }),
     prisma.tagGroupConfig.findMany({
-      select: { group: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
+      select: { group: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
     }),
     getSavedPostIds(currentUser?.id ?? null),
   ]);
@@ -227,16 +271,7 @@ export default async function HomePage() {
 
   // 배너 props 변환
   const bannerItems: BannerItem[] = homeBanners.map((b) => {
-    const topicLabel = b.post.postTopics
-      .filter((t) => t.isVisible)
-      .slice(0, 1)
-      .map((t) => ({ text: t.topic.nameEn, ...resolveTopicColors(t.topic) }));
-
-    const tagLabel = b.post.postTags
-      .filter((t) => t.isVisible)
-      .slice(0, 1)
-      .map((t) => ({ text: t.tag.name, ...resolveTagColors(t.tag, tagGroupMap.get(t.tag.group)) }));
-
+    const labels = resolveBannerLabels(b.post.postTopics, b.post.postTags, tagGroupMap);
     return {
       slug: b.post.slug,
       titleEn: b.post.titleEn,
@@ -248,7 +283,7 @@ export default async function HomePage() {
       focalX: b.post.postImages[0]?.focalX ?? null,
       focalY: b.post.postImages[0]?.focalY ?? null,
       zoom: b.post.postImages[0]?.zoom ?? null,
-      labels: [...topicLabel, ...tagLabel],
+      labels,
     };
   });
 

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -7,7 +7,8 @@ import {
   resolveTopicColors,
   resolveTagColors,
   K_MEDIA_GROUP,
-  labelGroupOrder,
+  selectHomeLabels,
+  type LabelSlot,
   type ColorNode,
   type TagGroupColorMap,
   type ResolvedLabel,
@@ -19,41 +20,18 @@ function resolveBannerLabels(
   postTags:   { isVisible: boolean; displayOrder: number; tag:   { name: string; group: string; colorHex?: string | null; colorHex2?: string | null; textColorHex?: string | null } }[],
   tagGroupMap: TagGroupColorMap,
 ): ResolvedLabel[] {
-  type Slot = { group: string; name: string; displayLabel: string | null; colors: Omit<ResolvedLabel, "text"> };
-
-  const topicSlots: Slot[] = postTopics
+  const topicSlots: LabelSlot[] = postTopics
     .filter((t) => t.isVisible)
-    .map((t) => ({
-      group: "TOPIC",
-      name: t.topic.nameEn,
-      displayLabel: null,
-      colors: resolveTopicColors(t.topic),
-    }));
+    .map((t) => ({ group: "TOPIC", name: t.topic.nameEn, displayLabel: null, colors: resolveTopicColors(t.topic) }));
 
-  const otherSlots: Slot[] = postTags
+  const otherSlots: LabelSlot[] = postTags
     .filter((t) => t.isVisible && t.tag.group !== K_MEDIA_GROUP)
     .map((t) => {
       const gc = tagGroupMap.get(t.tag.group);
       return { group: t.tag.group, name: t.tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(t.tag, gc) };
     });
 
-  // 슬롯 선택: 토픽 1 → non-K_MEDIA 태그 1 (부족하면 상호 보완)
-  const selected: Slot[] = [];
-  let topicUsed = 0, otherUsed = 0;
-  if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
-  else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
-  if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
-  else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
-
-  // 렌더링 순서 보정: 토픽 → K-MEDIA → 나머지 태그
-  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
-
-  // displayLabel 조건: 다른 그룹이 함께 표시될 때만 사용
-  return selected.map((slot) => {
-    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
-    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
-    return { text, ...slot.colors };
-  });
+  return selectHomeLabels(topicSlots, otherSlots);
 }
 import { PostCard } from "./_components/PostCard";
 import { SearchBar } from "./_components/SearchBar";

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -6,15 +6,16 @@ import { getPostsWithLabels, getSavedPostIds, type PostItem } from "@/lib/post-q
 import {
   resolveTopicColors,
   resolveTagColors,
+  K_MEDIA_GROUP,
+  labelGroupOrder,
+  type ColorNode,
   type TagGroupColorMap,
   type ResolvedLabel,
 } from "@/lib/post-labels";
 
-const K_SCENE_GROUP = "K_MEDIA";
-
 /** 홈 배너용 라벨 2개 선택 — PostCard home variant와 동일한 규칙 */
 function resolveBannerLabels(
-  postTopics: { isVisible: boolean; displayOrder: number; topic: { nameEn: string; colorHex?: string | null; colorHex2?: string | null; gradientDir?: string; gradientStop?: number; textColorHex?: string | null; parent?: unknown } }[],
+  postTopics: { isVisible: boolean; displayOrder: number; topic: { nameEn: string; colorHex?: string | null; colorHex2?: string | null; gradientDir?: string; gradientStop?: number; textColorHex?: string | null; parent?: ColorNode | null } }[],
   postTags:   { isVisible: boolean; displayOrder: number; tag:   { name: string; group: string; colorHex?: string | null; colorHex2?: string | null; textColorHex?: string | null } }[],
   tagGroupMap: TagGroupColorMap,
 ): ResolvedLabel[] {
@@ -26,12 +27,11 @@ function resolveBannerLabels(
       group: "TOPIC",
       name: t.topic.nameEn,
       displayLabel: null,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      colors: resolveTopicColors(t.topic as any),
+      colors: resolveTopicColors(t.topic),
     }));
 
   const otherSlots: Slot[] = postTags
-    .filter((t) => t.isVisible && t.tag.group !== K_SCENE_GROUP)
+    .filter((t) => t.isVisible && t.tag.group !== K_MEDIA_GROUP)
     .map((t) => {
       const gc = tagGroupMap.get(t.tag.group);
       return { group: t.tag.group, name: t.tag.name, displayLabel: gc?.displayLabel ?? null, colors: resolveTagColors(t.tag, gc) };
@@ -46,8 +46,7 @@ function resolveBannerLabels(
   else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
 
   // 렌더링 순서 보정: 토픽 → K-MEDIA → 나머지 태그
-  const ORDER = (g: string) => g === "TOPIC" ? 0 : g === K_SCENE_GROUP ? 1 : 2;
-  selected.sort((a, b) => ORDER(a.group) - ORDER(b.group));
+  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
 
   // displayLabel 조건: 다른 그룹이 함께 표시될 때만 사용
   return selected.map((slot) => {

--- a/src/app/(user)/posts/[slug]/page.tsx
+++ b/src/app/(user)/posts/[slug]/page.tsx
@@ -219,7 +219,7 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
   // 색상 resolve
   const configMap = new Map(tagGroupConfigs.map((c) => [c.group, c]));
 
-  const K_SCENE_GROUP = "K_SCENE";
+  const K_SCENE_GROUP = "K_MEDIA";
   const labels: ResolvedLabel[] = [
     ...post.postTopics.map(({ topic }) => ({ text: topic.nameEn, ...resolveTopicColors(topic) })),
     ...post.postTags.filter(({ tag }) => tag.group === K_SCENE_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),

--- a/src/app/(user)/posts/[slug]/page.tsx
+++ b/src/app/(user)/posts/[slug]/page.tsx
@@ -96,7 +96,7 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
     include: {
       postTopics: {
         where: { isVisible: true },
-        orderBy: { displayOrder: "asc" },
+        orderBy: [{ topic: { level: "asc" } }, { displayOrder: "asc" }],
         include: {
           topic: {
             select: {
@@ -180,7 +180,7 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
     },
   }),
     prisma.tagGroupConfig.findMany({
-      select: { group: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
+      select: { group: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
     }),
   ]);
 
@@ -219,9 +219,11 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
   // 색상 resolve
   const configMap = new Map(tagGroupConfigs.map((c) => [c.group, c]));
 
+  const K_SCENE_GROUP = "K_SCENE";
   const labels: ResolvedLabel[] = [
     ...post.postTopics.map(({ topic }) => ({ text: topic.nameEn, ...resolveTopicColors(topic) })),
-    ...post.postTags.map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
+    ...post.postTags.filter(({ tag }) => tag.group === K_SCENE_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
+    ...post.postTags.filter(({ tag }) => tag.group !== K_SCENE_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
   ];
 
   const currentUser = await getCurrentUser();

--- a/src/app/(user)/posts/[slug]/page.tsx
+++ b/src/app/(user)/posts/[slug]/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { Sparkles, Waves, Flame, Lightbulb } from "lucide-react";
 import { LocationCard } from "./_components/LocationCard";
 import { prisma } from "@/lib/prisma";
-import { resolveTopicColors, resolveTagColors, type ResolvedLabel } from "@/lib/post-labels";
+import { resolveTopicColors, resolveTagColors, K_MEDIA_GROUP, type ResolvedLabel } from "@/lib/post-labels";
 import { MarkdownContent } from "./_components/MarkdownContent";
 import { PostDetailHeader } from "./_components/PostDetailHeader";
 import { BannerCarousel } from "./_components/BannerCarousel";
@@ -219,11 +219,10 @@ export default async function PostDetailPage({ params, searchParams }: Props) {
   // 색상 resolve
   const configMap = new Map(tagGroupConfigs.map((c) => [c.group, c]));
 
-  const K_SCENE_GROUP = "K_MEDIA";
   const labels: ResolvedLabel[] = [
     ...post.postTopics.map(({ topic }) => ({ text: topic.nameEn, ...resolveTopicColors(topic) })),
-    ...post.postTags.filter(({ tag }) => tag.group === K_SCENE_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
-    ...post.postTags.filter(({ tag }) => tag.group !== K_SCENE_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
+    ...post.postTags.filter(({ tag }) => tag.group === K_MEDIA_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
+    ...post.postTags.filter(({ tag }) => tag.group !== K_MEDIA_GROUP).map(({ tag }) => ({ text: tag.name, ...resolveTagColors(tag, configMap.get(tag.group)) })),
   ];
 
   const currentUser = await getCurrentUser();

--- a/src/app/(user)/saved/_components/SavedClient.tsx
+++ b/src/app/(user)/saved/_components/SavedClient.tsx
@@ -12,6 +12,7 @@ import type { PostItem } from "@/lib/post-queries";
 
 type TagGroupConfig = {
   group: string;
+  displayLabel: string | null;
   colorHex: string;
   colorHex2: string | null;
   gradientDir: string;

--- a/src/app/(user)/saved/page.tsx
+++ b/src/app/(user)/saved/page.tsx
@@ -44,7 +44,7 @@ export default async function SavedPage() {
       })
       .then((rows) => rows.map((r) => r.targetId)),
     prisma.tagGroupConfig.findMany({
-      select: { group: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
+      select: { group: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
     }),
   ]);
 

--- a/src/app/admin/categories/_components/SortableTagList.tsx
+++ b/src/app/admin/categories/_components/SortableTagList.tsx
@@ -41,7 +41,8 @@ export interface TagItem {
 
 export interface TagGroupConfigItem {
   group: string;
-  nameEn: string;       // 라벨에 표시될 영어 이름 (빈 문자열 = group key 폴백)
+  nameEn: string;             // 라벨에 표시될 영어 이름 (빈 문자열 = group key 폴백)
+  displayLabel: string | null; // 포스트 라벨 표시용 짧은 이름 (null = 미사용)
   colorHex: string;
   colorHex2: string | null;
   gradientDir: string;
@@ -137,7 +138,7 @@ function SortableTagItem({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.4 : 1,
+    opacity: isDragging ? 0.4 : item.isActive ? 1 : 0.45,
     display: (hideInactive && !item.isActive) ? "none" : undefined,
   };
 

--- a/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
+++ b/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
@@ -113,7 +113,7 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
           <DialogTitle>
             {mode === "create"
               ? "새 Tag 그룹 추가"
-              : `${groupConfig!.group} 그룹 설정`}
+              : `${groupConfig!.nameEn || groupConfig!.group} 그룹 설정`}
           </DialogTitle>
         </DialogHeader>
 

--- a/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
+++ b/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
@@ -29,6 +29,7 @@ interface TagGroupConfigDialogProps {
 export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreated, onUpdated }: TagGroupConfigDialogProps) {
   const [isPending, startTransition] = useTransition();
   const [nameEn, setNameEn] = useState("");
+  const [displayLabel, setDisplayLabel] = useState("");
   const [isGradient, setIsGradient] = useState(false);
   const [colorHex, setColorHex] = useState("#C8FF09");
   const [colorHex2, setColorHex2] = useState("#ffffff");
@@ -41,6 +42,7 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
       if (mode === "edit" && groupConfig) {
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setNameEn(groupConfig.nameEn || groupConfig.group);
+        setDisplayLabel(groupConfig.displayLabel ?? "");
         setIsGradient(groupConfig.colorHex2 !== null);
         setColorHex(groupConfig.colorHex);
         setColorHex2(groupConfig.colorHex2 ?? "#ffffff");
@@ -49,6 +51,7 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
         setTextColorHex(groupConfig.textColorHex);
       } else {
         setNameEn("");
+        setDisplayLabel("");
         setIsGradient(false);
         setColorHex("#C8FF09");
         setColorHex2("#ffffff");
@@ -62,6 +65,7 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
   function handleSubmit() {
     const formData = {
       nameEn: nameEn.trim(),
+      displayLabel: displayLabel.trim() || null,
       colorHex,
       colorHex2: isGradient ? colorHex2 : null,
       gradientDir,
@@ -128,6 +132,20 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
                 그룹 키: <span className="font-mono font-semibold">{derivedKey}</span>
               </p>
             )}
+          </div>
+
+          {/* 포스트 라벨 표시명 */}
+          <div className="space-y-1.5">
+            <Label htmlFor="groupDisplayLabel">포스트 라벨 표시명</Label>
+            <Input
+              id="groupDisplayLabel"
+              value={displayLabel}
+              onChange={(e) => setDisplayLabel(e.target.value)}
+              placeholder="예: Spot (비워두면 미사용)"
+            />
+            <p className="text-xs text-muted-foreground">
+              포스트 상세 페이지에서 태그 라벨에 표시할 짧은 이름. 비워두면 표시 안 함.
+            </p>
           </div>
 
           <GradientColorSection

--- a/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
+++ b/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
@@ -103,7 +103,7 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
 
   if (mode === "edit" && !groupConfig) return null;
 
-  const previewName = nameEn.trim() || (mode === "edit" && groupConfig ? groupConfig.group : "NEW GROUP");
+  const previewName = displayLabel.trim();
   const derivedKey = nameEn.trim().toUpperCase().replace(/\W+/g, "_");
 
   return (
@@ -168,17 +168,19 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
           />
 
           {/* 미리보기 */}
-          <div className="flex items-center gap-2 pt-0.5">
-            <ColorLabel
-              name={previewName}
-              colorHex={colorHex}
-              colorHex2={isGradient ? colorHex2 : null}
-              gradientDir={gradientDir}
-              gradientStop={gradientStop}
-              textColorHex={textColorHex}
-            />
-            <span className="text-xs text-muted-foreground">미리보기</span>
-          </div>
+          {previewName && (
+            <div className="flex items-center gap-2 pt-0.5">
+              <ColorLabel
+                name={previewName}
+                colorHex={colorHex}
+                colorHex2={isGradient ? colorHex2 : null}
+                gradientDir={gradientDir}
+                gradientStop={gradientStop}
+                textColorHex={textColorHex}
+              />
+              <span className="text-xs text-muted-foreground">미리보기</span>
+            </div>
+          )}
         </div>
 
         <DialogFooter>

--- a/src/app/admin/categories/_components/TagsTabContent.tsx
+++ b/src/app/admin/categories/_components/TagsTabContent.tsx
@@ -95,9 +95,14 @@ function GroupColumn({
 
   return (
     <div
+      style={
+        !isDragging
+          ? { borderLeft: `3px solid ${groupConfig.isVisible ? groupConfig.colorHex : "#dddddd"}` }
+          : undefined
+      }
       className={`rounded-xl overflow-hidden bg-white shadow-sm transition-shadow ${
         isDragging ? "shadow-lg ring-2 ring-zinc-200" : ""
-      }`}
+      } ${groupConfig.isVisible ? "" : "opacity-50"}`}
     >
       {/* 컬럼 헤더 */}
       <div className="px-3 py-3 border-b border-border flex items-center gap-1.5 bg-muted/30">
@@ -108,15 +113,20 @@ function GroupColumn({
         >
           <GripVertical className="w-3.5 h-3.5" />
         </span>
-        <ColorLabel
-          name={groupConfig.nameEn || groupConfig.group}
-          colorHex={groupConfig.colorHex}
-          colorHex2={groupConfig.colorHex2}
-          gradientDir={groupConfig.gradientDir}
-          gradientStop={groupConfig.gradientStop}
-          textColorHex={groupConfig.textColorHex}
-          className="text-sm px-3 py-1"
-        />
+        <span className="text-sm font-bold shrink-0">
+          {groupConfig.nameEn || groupConfig.group}
+        </span>
+        {groupConfig.displayLabel && (
+          <ColorLabel
+            name={groupConfig.displayLabel}
+            colorHex={groupConfig.colorHex}
+            colorHex2={groupConfig.colorHex2}
+            gradientDir={groupConfig.gradientDir}
+            gradientStop={groupConfig.gradientStop}
+            textColorHex={groupConfig.textColorHex}
+            className="text-xs px-2.5 py-0.5"
+          />
+        )}
         <span className="flex-1" />
         <span className="text-xs tabular-nums text-muted-foreground shrink-0">{tags.length}</span>
         <button

--- a/src/app/admin/categories/actions.ts
+++ b/src/app/admin/categories/actions.ts
@@ -234,6 +234,7 @@ export type TagFormData = {
 
 export type TagGroupConfigFormData = {
   nameEn: string;
+  displayLabel: string | null;
   colorHex: string;
   colorHex2: string | null;
   gradientDir: string;
@@ -378,6 +379,7 @@ export async function checkTagSlug(
 export type TagGroupConfigData = {
   group: string;
   nameEn: string;
+  displayLabel: string | null;
   colorHex: string;
   colorHex2: string | null;
   gradientDir: string;
@@ -394,9 +396,9 @@ export async function upsertTagGroupConfig(
   try {
     const updated = await prisma.tagGroupConfig.upsert({
       where: { group },
-      update: { nameEn: data.nameEn, colorHex: data.colorHex, colorHex2: data.colorHex2, gradientDir: data.gradientDir, gradientStop: data.gradientStop, textColorHex: data.textColorHex },
-      create: { group, nameEn: data.nameEn, colorHex: data.colorHex, colorHex2: data.colorHex2, gradientDir: data.gradientDir, gradientStop: data.gradientStop, textColorHex: data.textColorHex },
-      select: { group: true, nameEn: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true, isVisible: true, sortOrder: true },
+      update: { nameEn: data.nameEn, displayLabel: data.displayLabel, colorHex: data.colorHex, colorHex2: data.colorHex2, gradientDir: data.gradientDir, gradientStop: data.gradientStop, textColorHex: data.textColorHex },
+      create: { group, nameEn: data.nameEn, displayLabel: data.displayLabel, colorHex: data.colorHex, colorHex2: data.colorHex2, gradientDir: data.gradientDir, gradientStop: data.gradientStop, textColorHex: data.textColorHex },
+      select: { group: true, nameEn: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true, isVisible: true, sortOrder: true },
     });
     revalidatePath("/admin/categories");
   revalidatePath("/category");
@@ -421,6 +423,7 @@ export async function reorderTagGroups(orderedGroups: string[]): Promise<void> {
 export type TagGroupConfigCreated = {
   group: string;
   nameEn: string;
+  displayLabel: string | null;
   colorHex: string;
   colorHex2: string | null;
   gradientDir: string;
@@ -441,8 +444,8 @@ export async function createTagGroup(
     const last = await prisma.tagGroupConfig.findFirst({ orderBy: { sortOrder: "desc" }, select: { sortOrder: true } });
     const sortOrder = (last?.sortOrder ?? -1) + 1;
     const created = await prisma.tagGroupConfig.create({
-      data: { group, nameEn: data.nameEn.trim(), colorHex: data.colorHex, colorHex2: data.colorHex2, gradientDir: data.gradientDir, gradientStop: data.gradientStop, textColorHex: data.textColorHex, sortOrder },
-      select: { group: true, nameEn: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true, isVisible: true, sortOrder: true },
+      data: { group, nameEn: data.nameEn.trim(), displayLabel: data.displayLabel, colorHex: data.colorHex, colorHex2: data.colorHex2, gradientDir: data.gradientDir, gradientStop: data.gradientStop, textColorHex: data.textColorHex, sortOrder },
+      select: { group: true, nameEn: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true, isVisible: true, sortOrder: true },
     });
     revalidatePath("/admin/categories");
   revalidatePath("/category");

--- a/src/app/admin/categories/page.tsx
+++ b/src/app/admin/categories/page.tsx
@@ -106,7 +106,7 @@ export default async function CategoriesPage({
       },
     }),
     prisma.tagGroupConfig.findMany({
-      select: { group: true, nameEn: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true, isVisible: true, sortOrder: true },
+      select: { group: true, nameEn: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true, isVisible: true, sortOrder: true },
       orderBy: { sortOrder: "asc" },
     }),
   ]);
@@ -122,6 +122,7 @@ export default async function CategoriesPage({
   const groupConfigs: TagGroupConfigItem[] = rawGroupConfigs.map((c) => ({
     group: c.group,
     nameEn: c.nameEn,
+    displayLabel: c.displayLabel,
     colorHex: c.colorHex,
     colorHex2: c.colorHex2,
     gradientDir: c.gradientDir,

--- a/src/app/admin/posts/[id]/edit/page.tsx
+++ b/src/app/admin/posts/[id]/edit/page.tsx
@@ -99,6 +99,7 @@ export default async function EditPostPage({ params, searchParams }: Props) {
       select: {
         group: true,
         nameEn: true,
+        displayLabel: true,
         colorHex: true,
         colorHex2: true,
         gradientDir: true,
@@ -141,6 +142,7 @@ export default async function EditPostPage({ params, searchParams }: Props) {
   const tagGroups = tagGroupConfigs.map((c) => ({
     group: c.group,
     nameEn: c.nameEn,
+    displayLabel: c.displayLabel,
     colorHex: c.colorHex,
     colorHex2: c.colorHex2,
     gradientDir: c.gradientDir,

--- a/src/app/admin/posts/_components/LabelVisibilityCard.tsx
+++ b/src/app/admin/posts/_components/LabelVisibilityCard.tsx
@@ -20,7 +20,15 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { TopicForForm, TagForForm, TagGroupItem } from "./PostForm";
-import { K_MEDIA_GROUP, labelGroupOrder } from "@/lib/post-labels";
+import {
+  K_MEDIA_GROUP,
+  labelBackground,
+  selectHomeLabels,
+  selectListLabels,
+  type LabelSlot,
+  type ResolvedLabel,
+  type EffectiveColorInfo,
+} from "@/lib/post-labels";
 
 
 type PostTopicState = { topicId: string; isVisible: boolean; displayOrder: number };
@@ -35,30 +43,14 @@ type SectionItem = {
   hint?: string;
 };
 
-type PreviewLabel = { text: string; background: string; color: string };
-type PreviewSlot = {
-  group: string;
-  name: string;
-  displayLabel: string | null;
-  background: string;
-  color: string;
-};
-
-function getTagColors(tag: TagForForm): { background: string; color: string } {
-  const background = tag.effectiveColorHex2
-    ? `linear-gradient(${tag.effectiveGradientDir}, ${tag.effectiveColorHex} 0%, ${tag.effectiveColorHex2} ${tag.effectiveGradientStop}%)`
-    : tag.effectiveColorHex;
-  return { background, color: tag.effectiveTextColorHex };
-}
-
 // ─── 미리보기 ─────────────────────────────────────────────────────────────────
 
 function PreviewSection({
   preview,
 }: {
-  preview: { home: PreviewLabel[]; list: PreviewLabel[]; detail: PreviewLabel[] };
+  preview: { home: ResolvedLabel[]; list: ResolvedLabel[]; detail: ResolvedLabel[] };
 }) {
-  const rows: { label: string; labels: PreviewLabel[] }[] = [
+  const rows: { label: string; labels: ResolvedLabel[] }[] = [
     { label: "홈", labels: preview.home },
     { label: "목록", labels: preview.list },
     { label: "상세", labels: preview.detail },
@@ -76,7 +68,7 @@ function PreviewSection({
                 <span className="text-[10px] text-muted-foreground/30 italic pt-[3px]">없음</span>
               ) : (
                 labels.map((l, i) => (
-                  <LabelBadge key={i} text={l.text} background={l.background} color={l.color} />
+                  <LabelBadge key={i} text={l.text} background={labelBackground(l)} color={l.textColorHex} />
                 ))
               )}
             </div>
@@ -229,6 +221,7 @@ interface Props {
   allTopics: TopicForForm[];
   allTags: TagForForm[];
   topicEffectiveStyleMap: Map<string, React.CSSProperties>;
+  topicEffectiveInfoMap: Map<string, EffectiveColorInfo>;
   tagGroups: TagGroupItem[];
 }
 
@@ -237,6 +230,7 @@ export function LabelVisibilityCard({
   postTags, setPostTags,
   allTopics, allTags,
   topicEffectiveStyleMap,
+  topicEffectiveInfoMap,
   tagGroups,
 }: Props) {
   const sensors = useSensors(useSensor(PointerSensor));
@@ -267,7 +261,8 @@ export function LabelVisibilityCard({
       .sort((a, b) => a.displayOrder - b.displayOrder)
       .map((pt) => {
         const t = tagMap.get(pt.tagId);
-        const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
+        const background = t ? (t.effectiveColorHex2 ? `linear-gradient(${t.effectiveGradientDir}, ${t.effectiveColorHex}, ${t.effectiveColorHex2} ${t.effectiveGradientStop}%)` : t.effectiveColorHex) : "";
+        const color = t?.effectiveTextColorHex ?? "#000";
         return { id: pt.tagId, isVisible: pt.isVisible, label: t?.name ?? pt.tagId, background, color };
       }),
   [postTags, tagMap]);
@@ -278,7 +273,8 @@ export function LabelVisibilityCard({
       .sort((a, b) => a.displayOrder - b.displayOrder)
       .map((pt) => {
         const t = tagMap.get(pt.tagId);
-        const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
+        const background = t ? (t.effectiveColorHex2 ? `linear-gradient(${t.effectiveGradientDir}, ${t.effectiveColorHex}, ${t.effectiveColorHex2} ${t.effectiveGradientStop}%)` : t.effectiveColorHex) : "";
+        const color = t?.effectiveTextColorHex ?? "#000";
         const hint = t ? (tagGroupMap.get(t.group)?.displayLabel ?? undefined) : undefined;
         return { id: pt.tagId, isVisible: pt.isVisible, label: t?.name ?? pt.tagId, background, color, hint };
       }),
@@ -287,80 +283,59 @@ export function LabelVisibilityCard({
   // ─── 미리보기 계산 ──────────────────────────────────────────────────────────
 
   const preview = useMemo(() => {
-    const visibleTopics = [...postTopics]
-      .filter((pt) => pt.isVisible)
-      .sort((a, b) => a.displayOrder - b.displayOrder);
-    const visibleKmedia = [...postTags]
-      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group === K_MEDIA_GROUP)
-      .sort((a, b) => a.displayOrder - b.displayOrder);
-    const visibleOther = [...postTags]
-      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group !== K_MEDIA_GROUP)
-      .sort((a, b) => a.displayOrder - b.displayOrder);
-
-    const topicSlots: PreviewSlot[] = visibleTopics.map((pt) => {
-      const s = topicEffectiveStyleMap.get(pt.topicId) ?? {};
+    const toTopicColors = (topicId: string): Omit<ResolvedLabel, "text"> => {
+      const info = topicEffectiveInfoMap.get(topicId);
       return {
-        group: "TOPIC",
-        name: topicMap.get(pt.topicId)?.nameEn ?? pt.topicId,
-        displayLabel: null,
-        background: String(s.background ?? ""),
-        color: String(s.color ?? "#000"),
+        colorHex: info?.hex ?? "#e4e4e7",
+        colorHex2: info?.hex2 ?? null,
+        gradientDir: info?.dir ?? "to bottom",
+        gradientStop: info?.stop ?? 150,
+        textColorHex: info?.textHex ?? "#000000",
       };
+    };
+    const toTagColors = (t: TagForForm): Omit<ResolvedLabel, "text"> => ({
+      colorHex: t.effectiveColorHex,
+      colorHex2: t.effectiveColorHex2 ?? null,
+      gradientDir: t.effectiveGradientDir,
+      gradientStop: t.effectiveGradientStop,
+      textColorHex: t.effectiveTextColorHex,
     });
 
-    const kmediaSlots: PreviewSlot[] = visibleKmedia.map((pt) => {
-      const t = tagMap.get(pt.tagId)!;
-      const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
-      return { group: K_MEDIA_GROUP, name: t?.name ?? pt.tagId, displayLabel: null, background, color };
+    const visibleTopics = [...postTopics].filter((pt) => pt.isVisible).sort((a, b) => a.displayOrder - b.displayOrder);
+    const visibleKmedia = [...postTags].filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group === K_MEDIA_GROUP).sort((a, b) => a.displayOrder - b.displayOrder);
+    const visibleOther = [...postTags].filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group !== K_MEDIA_GROUP).sort((a, b) => a.displayOrder - b.displayOrder);
+
+    const topicSlots: LabelSlot[] = visibleTopics.map((pt) => ({
+      group: "TOPIC",
+      name: topicMap.get(pt.topicId)?.nameEn ?? pt.topicId,
+      displayLabel: null,
+      colors: toTopicColors(pt.topicId),
+    }));
+
+    const kmediaSlots: LabelSlot[] = visibleKmedia.map((pt) => {
+      const t = tagMap.get(pt.tagId);
+      return { group: K_MEDIA_GROUP, name: t?.name ?? pt.tagId, displayLabel: null, colors: t ? toTagColors(t) : { colorHex: "#e4e4e7", colorHex2: null, gradientDir: "to bottom", gradientStop: 150, textColorHex: "#000000" } };
     });
 
-    const otherSlots: PreviewSlot[] = visibleOther.map((pt) => {
-      const t = tagMap.get(pt.tagId)!;
-      const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
+    const otherSlots: LabelSlot[] = visibleOther.map((pt) => {
+      const t = tagMap.get(pt.tagId);
       const displayLabel = t ? (tagGroupMap.get(t.group)?.displayLabel ?? null) : null;
-      return { group: t?.group ?? "OTHER", name: t?.name ?? pt.tagId, displayLabel, background, color };
+      return { group: t?.group ?? "OTHER", name: t?.name ?? pt.tagId, displayLabel, colors: t ? toTagColors(t) : { colorHex: "#e4e4e7", colorHex2: null, gradientDir: "to bottom", gradientStop: 150, textColorHex: "#000000" } };
     });
 
-    function applyText(selected: PreviewSlot[]): PreviewLabel[] {
-      selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
-      return selected.map((slot) => {
-        const hasOtherGroup = selected.some((s) => s.group !== slot.group);
-        const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
-        return { text, background: slot.background, color: slot.color };
-      });
-    }
-
-    // 홈
-    const homeSelected: PreviewSlot[] = [];
-    let hT = 0, hO = 0;
-    if (hT < topicSlots.length) homeSelected.push(topicSlots[hT++]);
-    else if (hO < otherSlots.length) homeSelected.push(otherSlots[hO++]);
-    if (hO < otherSlots.length) homeSelected.push(otherSlots[hO++]);
-    else if (hT < topicSlots.length) homeSelected.push(topicSlots[hT++]);
-
-    // 목록
-    const listSelected: PreviewSlot[] = [];
-    let lT = 0, lK = 0, lO = 0;
-    if (lT < topicSlots.length) listSelected.push(topicSlots[lT++]);
-    if (lK < kmediaSlots.length) listSelected.push(kmediaSlots[lK++]);
-    if (lO < otherSlots.length) listSelected.push(otherSlots[lO++]);
-    if (listSelected.length < 3) {
-      const remaining = [...topicSlots.slice(lT), ...kmediaSlots.slice(lK), ...otherSlots.slice(lO)];
-      for (const slot of remaining) {
-        if (listSelected.length >= 3) break;
-        listSelected.push(slot);
-      }
-    }
-
-    // 상세
-    const detailLabels: PreviewLabel[] = [
-      ...topicSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
-      ...kmediaSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
-      ...otherSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
+    // 상세: 모든 visible 라벨 전부 (TOPIC → K_MEDIA → OTHER 순)
+    const detail: ResolvedLabel[] = [
+      ...topicSlots.map((s) => ({ text: s.name, ...s.colors })),
+      ...kmediaSlots.map((s) => ({ text: s.name, ...s.colors })),
+      ...otherSlots.map((s) => ({ text: s.name, ...s.colors })),
     ];
 
-    return { home: applyText(homeSelected), list: applyText(listSelected), detail: detailLabels };
-  }, [postTopics, postTags, topicMap, tagMap, topicEffectiveStyleMap, tagGroupMap]);
+    return {
+      home: selectHomeLabels(topicSlots, otherSlots),
+      list: selectListLabels(topicSlots, kmediaSlots, otherSlots),
+      detail,
+    };
+  }, [postTopics, postTags, topicMap, tagMap, topicEffectiveInfoMap, tagGroupMap]);
 
   // ─── 드래그 핸들러 ──────────────────────────────────────────────────────────
 

--- a/src/app/admin/posts/_components/LabelVisibilityCard.tsx
+++ b/src/app/admin/posts/_components/LabelVisibilityCard.tsx
@@ -21,7 +21,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { TopicForForm, TagForForm, TagGroupItem } from "./PostForm";
 
-const K_SCENE_GROUP = "K_SCENE";
+const K_SCENE_GROUP = "K_MEDIA";
 
 type PostTopicState = { topicId: string; isVisible: boolean; displayOrder: number };
 type PostTagState = { tagId: string; isVisible: boolean; displayOrder: number };

--- a/src/app/admin/posts/_components/LabelVisibilityCard.tsx
+++ b/src/app/admin/posts/_components/LabelVisibilityCard.tsx
@@ -321,7 +321,10 @@ export function LabelVisibilityCard({
       return { group: t?.group ?? "OTHER", name: t?.name ?? pt.tagId, displayLabel, background, color };
     });
 
+    const ORDER = (g: string) => g === "TOPIC" ? 0 : g === K_SCENE_GROUP ? 1 : 2;
+
     function applyText(selected: PreviewSlot[]): PreviewLabel[] {
+      selected.sort((a, b) => ORDER(a.group) - ORDER(b.group));
       return selected.map((slot) => {
         const hasOtherGroup = selected.some((s) => s.group !== slot.group);
         const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;

--- a/src/app/admin/posts/_components/LabelVisibilityCard.tsx
+++ b/src/app/admin/posts/_components/LabelVisibilityCard.tsx
@@ -19,7 +19,9 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { TopicForForm, TagForForm } from "./PostForm";
+import type { TopicForForm, TagForForm, TagGroupItem } from "./PostForm";
+
+const K_SCENE_GROUP = "K_SCENE";
 
 type PostTopicState = { topicId: string; isVisible: boolean; displayOrder: number };
 type PostTagState = { tagId: string; isVisible: boolean; displayOrder: number };
@@ -28,6 +30,16 @@ type SectionItem = {
   id: string;
   isVisible: boolean;
   label: string;
+  background: string;
+  color: string;
+  hint?: string;
+};
+
+type PreviewLabel = { text: string; background: string; color: string };
+type PreviewSlot = {
+  group: string;
+  name: string;
+  displayLabel: string | null;
   background: string;
   color: string;
 };
@@ -39,29 +51,124 @@ function getTagColors(tag: TagForForm): { background: string; color: string } {
   return { background, color: tag.effectiveTextColorHex };
 }
 
-function SortableLabel({ item, isFirst }: { item: SectionItem; isFirst: boolean }) {
+// ─── 미리보기 ─────────────────────────────────────────────────────────────────
+
+function PreviewSection({
+  preview,
+}: {
+  preview: { home: PreviewLabel[]; list: PreviewLabel[]; detail: PreviewLabel[] };
+}) {
+  const rows: { label: string; labels: PreviewLabel[] }[] = [
+    { label: "홈", labels: preview.home },
+    { label: "목록", labels: preview.list },
+    { label: "상세", labels: preview.detail },
+  ];
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest">미리보기</p>
+      <div className="space-y-1.5">
+        {rows.map(({ label, labels }) => (
+          <div key={label} className="flex items-start gap-2.5">
+            <span className="text-xs font-semibold text-muted-foreground/60 w-7 shrink-0 pt-[3px]">{label}</span>
+            <div className="flex flex-wrap gap-1 [--pill-fs:0.625rem]">
+              {labels.length === 0 ? (
+                <span className="text-[10px] text-muted-foreground/30 italic pt-[3px]">없음</span>
+              ) : (
+                labels.map((l, i) => (
+                  <LabelBadge key={i} text={l.text} background={l.background} color={l.color} />
+                ))
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── 통합 행 컴포넌트 ──────────────────────────────────────────────────────────
+
+function SortableItemRow({
+  item,
+  isFirst,
+  showGrip,
+  onToggle,
+}: {
+  item: SectionItem;
+  isFirst: boolean;
+  showGrip: boolean;
+  onToggle: (id: string) => void;
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: item.id });
+
   return (
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.5 : 1 }}
-      className="flex items-center gap-1.5 rounded-md border bg-background px-2 py-1"
+      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }}
+      className="flex items-center gap-2 rounded-md border border-border/30 bg-background px-2 py-1.5"
     >
-      <span {...attributes} {...listeners} className="cursor-grab text-muted-foreground hover:text-foreground shrink-0">
+      <span
+        {...(showGrip ? { ...attributes, ...listeners } : {})}
+        className={`shrink-0 text-muted-foreground ${showGrip ? "cursor-grab hover:text-foreground" : "invisible pointer-events-none"}`}
+      >
         <GripVertical className="h-3.5 w-3.5" />
       </span>
+      <button
+        type="button"
+        onClick={() => onToggle(item.id)}
+        className="shrink-0 text-foreground transition-colors hover:text-muted-foreground"
+      >
+        <Eye className="h-3.5 w-3.5" />
+      </button>
       <LabelBadge text={item.label} background={item.background} color={item.color} />
-      {isFirst && (
-        <span className="ml-auto text-[10px] font-medium text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-          대표
-        </span>
+      <div className="ml-auto flex items-center gap-2 shrink-0">
+        {isFirst && (
+          <span className="text-[10px] font-medium text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            대표
+          </span>
+        )}
+        {item.hint && (
+          <span className="text-[10px] text-muted-foreground/55">→ &ldquo;{item.hint}&rdquo;</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StaticItemRow({
+  item,
+  onToggle,
+}: {
+  item: SectionItem;
+  onToggle: (id: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-background px-2 py-1.5 opacity-40">
+      <span className="invisible shrink-0 pointer-events-none">
+        <GripVertical className="h-3.5 w-3.5" />
+      </span>
+      <button
+        type="button"
+        onClick={() => onToggle(item.id)}
+        className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <EyeOff className="h-3.5 w-3.5" />
+      </button>
+      <LabelBadge text={item.label} background={item.background} color={item.color} />
+      {item.hint && (
+        <div className="ml-auto shrink-0">
+          <span className="text-[10px] text-muted-foreground/55">→ &ldquo;{item.hint}&rdquo;</span>
+        </div>
       )}
     </div>
   );
 }
 
-function LabelSection({
+// ─── 그룹 섹션 ────────────────────────────────────────────────────────────────
+
+function GroupSection({
   title,
   dndId,
   items,
@@ -76,42 +183,43 @@ function LabelSection({
   onToggle: (id: string) => void;
   onDragEnd: (event: DragEndEvent) => void;
 }) {
-  const visibleItems = items.filter((item) => item.isVisible);
+  if (items.length === 0) return null;
+
+  const visibleItems = items.filter((i) => i.isVisible);
+  const invisibleItems = items.filter((i) => !i.isVisible);
+  const showGrip = visibleItems.length > 1;
 
   return (
-    <div className="space-y-2">
-      <p className="text-xs text-muted-foreground font-medium">{title}</p>
+    <div className="space-y-1.5">
+      {/* 섹션 헤더 */}
+      <div className="flex items-center gap-2">
+        <span className="w-[3px] h-3.5 rounded-full bg-muted-foreground/30 shrink-0" />
+        <p className="text-xs font-semibold text-foreground/75">{title}</p>
+      </div>
+
       <div className="space-y-1">
-        {items.map((item) => (
-          <div key={item.id} className="flex items-center gap-2 text-xs">
-            <button
-              type="button"
-              onClick={() => onToggle(item.id)}
-              className={`shrink-0 transition-colors ${item.isVisible ? "text-foreground" : "text-muted-foreground/40"}`}
-            >
-              {item.isVisible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
-            </button>
-            <LabelBadge text={item.label} background={item.background} color={item.color} />
-          </div>
+        <DndContext id={dndId} sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+          <SortableContext items={visibleItems.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+            {visibleItems.map((item, idx) => (
+              <SortableItemRow
+                key={item.id}
+                item={item}
+                isFirst={idx === 0}
+                showGrip={showGrip}
+                onToggle={onToggle}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+        {invisibleItems.map((item) => (
+          <StaticItemRow key={item.id} item={item} onToggle={onToggle} />
         ))}
       </div>
-      {visibleItems.length > 1 && (
-        <div className="space-y-1">
-          <p className="text-xs text-muted-foreground">순서 (드래그)</p>
-          <DndContext id={dndId} sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-            <SortableContext items={visibleItems.map((item) => item.id)} strategy={verticalListSortingStrategy}>
-              <div className="space-y-1">
-                {visibleItems.map((item, idx) => (
-                  <SortableLabel key={item.id} item={item} isFirst={idx === 0} />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
-        </div>
-      )}
     </div>
   );
 }
+
+// ─── 메인 컴포넌트 ────────────────────────────────────────────────────────────
 
 interface Props {
   postTopics: PostTopicState[];
@@ -121,6 +229,7 @@ interface Props {
   allTopics: TopicForForm[];
   allTags: TagForForm[];
   topicEffectiveStyleMap: Map<string, React.CSSProperties>;
+  tagGroups: TagGroupItem[];
 }
 
 export function LabelVisibilityCard({
@@ -128,13 +237,17 @@ export function LabelVisibilityCard({
   postTags, setPostTags,
   allTopics, allTags,
   topicEffectiveStyleMap,
+  tagGroups,
 }: Props) {
   const sensors = useSensors(useSensor(PointerSensor));
   const topicMap = useMemo(() => new Map(allTopics.map((t) => [t.id, t])), [allTopics]);
   const tagMap = useMemo(() => new Map(allTags.map((t) => [t.id, t])), [allTags]);
+  const tagGroupMap = useMemo(() => new Map(tagGroups.map((g) => [g.group, g])), [tagGroups]);
+
+  // ─── 섹션별 아이템 ──────────────────────────────────────────────────────────
 
   const topicItems = useMemo<SectionItem[]>(() =>
-    postTopics
+    [...postTopics]
       .sort((a, b) => a.displayOrder - b.displayOrder)
       .map((pt) => {
         const s = topicEffectiveStyleMap.get(pt.topicId) ?? {};
@@ -148,42 +261,140 @@ export function LabelVisibilityCard({
       }),
   [postTopics, topicMap, topicEffectiveStyleMap]);
 
-  const tagItems = useMemo<SectionItem[]>(() =>
-    postTags
+  const ksceneItems = useMemo<SectionItem[]>(() =>
+    [...postTags]
+      .filter((pt) => tagMap.get(pt.tagId)?.group === K_SCENE_GROUP)
       .sort((a, b) => a.displayOrder - b.displayOrder)
       .map((pt) => {
         const t = tagMap.get(pt.tagId);
         const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
-        return {
-          id: pt.tagId,
-          isVisible: pt.isVisible,
-          label: t?.name ?? pt.tagId,
-          background,
-          color,
-        };
+        return { id: pt.tagId, isVisible: pt.isVisible, label: t?.name ?? pt.tagId, background, color };
       }),
   [postTags, tagMap]);
+
+  const otherTagItems = useMemo<SectionItem[]>(() =>
+    [...postTags]
+      .filter((pt) => tagMap.get(pt.tagId)?.group !== K_SCENE_GROUP)
+      .sort((a, b) => a.displayOrder - b.displayOrder)
+      .map((pt) => {
+        const t = tagMap.get(pt.tagId);
+        const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
+        const hint = t ? (tagGroupMap.get(t.group)?.displayLabel ?? undefined) : undefined;
+        return { id: pt.tagId, isVisible: pt.isVisible, label: t?.name ?? pt.tagId, background, color, hint };
+      }),
+  [postTags, tagMap, tagGroupMap]);
+
+  // ─── 미리보기 계산 ──────────────────────────────────────────────────────────
+
+  const preview = useMemo(() => {
+    const visibleTopics = [...postTopics]
+      .filter((pt) => pt.isVisible)
+      .sort((a, b) => a.displayOrder - b.displayOrder);
+    const visibleKscene = [...postTags]
+      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group === K_SCENE_GROUP)
+      .sort((a, b) => a.displayOrder - b.displayOrder);
+    const visibleOther = [...postTags]
+      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group !== K_SCENE_GROUP)
+      .sort((a, b) => a.displayOrder - b.displayOrder);
+
+    const topicSlots: PreviewSlot[] = visibleTopics.map((pt) => {
+      const s = topicEffectiveStyleMap.get(pt.topicId) ?? {};
+      return {
+        group: "TOPIC",
+        name: topicMap.get(pt.topicId)?.nameEn ?? pt.topicId,
+        displayLabel: null,
+        background: String(s.background ?? ""),
+        color: String(s.color ?? "#000"),
+      };
+    });
+
+    const ksceneSlots: PreviewSlot[] = visibleKscene.map((pt) => {
+      const t = tagMap.get(pt.tagId)!;
+      const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
+      return { group: K_SCENE_GROUP, name: t?.name ?? pt.tagId, displayLabel: null, background, color };
+    });
+
+    const otherSlots: PreviewSlot[] = visibleOther.map((pt) => {
+      const t = tagMap.get(pt.tagId)!;
+      const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
+      const displayLabel = t ? (tagGroupMap.get(t.group)?.displayLabel ?? null) : null;
+      return { group: t?.group ?? "OTHER", name: t?.name ?? pt.tagId, displayLabel, background, color };
+    });
+
+    function applyText(selected: PreviewSlot[]): PreviewLabel[] {
+      return selected.map((slot) => {
+        const hasOtherGroup = selected.some((s) => s.group !== slot.group);
+        const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
+        return { text, background: slot.background, color: slot.color };
+      });
+    }
+
+    // 홈
+    const homeSelected: PreviewSlot[] = [];
+    let hT = 0, hO = 0;
+    if (hT < topicSlots.length) homeSelected.push(topicSlots[hT++]);
+    else if (hO < otherSlots.length) homeSelected.push(otherSlots[hO++]);
+    if (hO < otherSlots.length) homeSelected.push(otherSlots[hO++]);
+    else if (hT < topicSlots.length) homeSelected.push(topicSlots[hT++]);
+
+    // 목록
+    const listSelected: PreviewSlot[] = [];
+    let lT = 0, lK = 0, lO = 0;
+    if (lT < topicSlots.length) listSelected.push(topicSlots[lT++]);
+    if (lK < ksceneSlots.length) listSelected.push(ksceneSlots[lK++]);
+    if (lO < otherSlots.length) listSelected.push(otherSlots[lO++]);
+    if (listSelected.length < 3) {
+      const remaining = [...topicSlots.slice(lT), ...ksceneSlots.slice(lK), ...otherSlots.slice(lO)];
+      for (const slot of remaining) {
+        if (listSelected.length >= 3) break;
+        listSelected.push(slot);
+      }
+    }
+
+    // 상세
+    const detailLabels: PreviewLabel[] = [
+      ...topicSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
+      ...ksceneSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
+      ...otherSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
+    ];
+
+    return { home: applyText(homeSelected), list: applyText(listSelected), detail: detailLabels };
+  }, [postTopics, postTags, topicMap, tagMap, topicEffectiveStyleMap, tagGroupMap]);
+
+  // ─── 드래그 핸들러 ──────────────────────────────────────────────────────────
 
   const handleTopicDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const visibleTopics = topicItems.filter((i) => i.isVisible);
-    const oldIndex = visibleTopics.findIndex((i) => i.id === active.id);
-    const newIndex = visibleTopics.findIndex((i) => i.id === over.id);
-    if (oldIndex === -1 || newIndex === -1) return;
-    arrayMove(visibleTopics, oldIndex, newIndex).forEach((item, idx) => {
+    const visible = topicItems.filter((i) => i.isVisible);
+    const oldIdx = visible.findIndex((i) => i.id === active.id);
+    const newIdx = visible.findIndex((i) => i.id === over.id);
+    if (oldIdx === -1 || newIdx === -1) return;
+    arrayMove(visible, oldIdx, newIdx).forEach((item, idx) => {
       setPostTopics((prev) => prev.map((pt) => pt.topicId === item.id ? { ...pt, displayOrder: idx } : pt));
     });
   };
 
-  const handleTagDragEnd = (event: DragEndEvent) => {
+  const handleKsceneDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const visibleTags = tagItems.filter((i) => i.isVisible);
-    const oldIndex = visibleTags.findIndex((i) => i.id === active.id);
-    const newIndex = visibleTags.findIndex((i) => i.id === over.id);
-    if (oldIndex === -1 || newIndex === -1) return;
-    arrayMove(visibleTags, oldIndex, newIndex).forEach((item, idx) => {
+    const visible = ksceneItems.filter((i) => i.isVisible);
+    const oldIdx = visible.findIndex((i) => i.id === active.id);
+    const newIdx = visible.findIndex((i) => i.id === over.id);
+    if (oldIdx === -1 || newIdx === -1) return;
+    arrayMove(visible, oldIdx, newIdx).forEach((item, idx) => {
+      setPostTags((prev) => prev.map((pt) => pt.tagId === item.id ? { ...pt, displayOrder: idx } : pt));
+    });
+  };
+
+  const handleOtherDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const visible = otherTagItems.filter((i) => i.isVisible);
+    const oldIdx = visible.findIndex((i) => i.id === active.id);
+    const newIdx = visible.findIndex((i) => i.id === over.id);
+    if (oldIdx === -1 || newIdx === -1) return;
+    arrayMove(visible, oldIdx, newIdx).forEach((item, idx) => {
       setPostTags((prev) => prev.map((pt) => pt.tagId === item.id ? { ...pt, displayOrder: idx } : pt));
     });
   };
@@ -195,27 +406,41 @@ export function LabelVisibilityCard({
       <CardHeader>
         <CardTitle className="text-sm font-semibold">라벨 표시 설정</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4">
-        {postTopics.length > 0 && (
-          <LabelSection
-            title="토픽"
-            dndId="label-topics-dnd"
-            items={topicItems}
-            sensors={sensors}
-            onToggle={(id) => setPostTopics((prev) => prev.map((pt) => pt.topicId === id ? { ...pt, isVisible: !pt.isVisible } : pt))}
-            onDragEnd={handleTopicDragEnd}
-          />
-        )}
-        {postTags.length > 0 && (
-          <LabelSection
-            title="태그"
-            dndId="label-tags-dnd"
-            items={tagItems}
-            sensors={sensors}
-            onToggle={(id) => setPostTags((prev) => prev.map((pt) => pt.tagId === id ? { ...pt, isVisible: !pt.isVisible } : pt))}
-            onDragEnd={handleTagDragEnd}
-          />
-        )}
+      <CardContent className="space-y-5">
+
+        {/* ── 미리보기 ── */}
+        <PreviewSection preview={preview} />
+
+        {/* ── 토픽 ── */}
+        <GroupSection
+          title="토픽"
+          dndId="label-topics-dnd"
+          items={topicItems}
+          sensors={sensors}
+          onToggle={(id) => setPostTopics((prev) => prev.map((pt) => pt.topicId === id ? { ...pt, isVisible: !pt.isVisible } : pt))}
+          onDragEnd={handleTopicDragEnd}
+        />
+
+        {/* ── K-MEDIA 태그 ── */}
+        <GroupSection
+          title="K-MEDIA 태그"
+          dndId="label-kscene-dnd"
+          items={ksceneItems}
+          sensors={sensors}
+          onToggle={(id) => setPostTags((prev) => prev.map((pt) => pt.tagId === id ? { ...pt, isVisible: !pt.isVisible } : pt))}
+          onDragEnd={handleKsceneDragEnd}
+        />
+
+        {/* ── 나머지 태그 ── */}
+        <GroupSection
+          title="나머지 태그"
+          dndId="label-other-dnd"
+          items={otherTagItems}
+          sensors={sensors}
+          onToggle={(id) => setPostTags((prev) => prev.map((pt) => pt.tagId === id ? { ...pt, isVisible: !pt.isVisible } : pt))}
+          onDragEnd={handleOtherDragEnd}
+        />
+
       </CardContent>
     </Card>
   );

--- a/src/app/admin/posts/_components/LabelVisibilityCard.tsx
+++ b/src/app/admin/posts/_components/LabelVisibilityCard.tsx
@@ -20,8 +20,8 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { TopicForForm, TagForForm, TagGroupItem } from "./PostForm";
+import { K_MEDIA_GROUP, labelGroupOrder } from "@/lib/post-labels";
 
-const K_SCENE_GROUP = "K_MEDIA";
 
 type PostTopicState = { topicId: string; isVisible: boolean; displayOrder: number };
 type PostTagState = { tagId: string; isVisible: boolean; displayOrder: number };
@@ -261,9 +261,9 @@ export function LabelVisibilityCard({
       }),
   [postTopics, topicMap, topicEffectiveStyleMap]);
 
-  const ksceneItems = useMemo<SectionItem[]>(() =>
+  const kmediaItems = useMemo<SectionItem[]>(() =>
     [...postTags]
-      .filter((pt) => tagMap.get(pt.tagId)?.group === K_SCENE_GROUP)
+      .filter((pt) => tagMap.get(pt.tagId)?.group === K_MEDIA_GROUP)
       .sort((a, b) => a.displayOrder - b.displayOrder)
       .map((pt) => {
         const t = tagMap.get(pt.tagId);
@@ -274,7 +274,7 @@ export function LabelVisibilityCard({
 
   const otherTagItems = useMemo<SectionItem[]>(() =>
     [...postTags]
-      .filter((pt) => tagMap.get(pt.tagId)?.group !== K_SCENE_GROUP)
+      .filter((pt) => tagMap.get(pt.tagId)?.group !== K_MEDIA_GROUP)
       .sort((a, b) => a.displayOrder - b.displayOrder)
       .map((pt) => {
         const t = tagMap.get(pt.tagId);
@@ -290,11 +290,11 @@ export function LabelVisibilityCard({
     const visibleTopics = [...postTopics]
       .filter((pt) => pt.isVisible)
       .sort((a, b) => a.displayOrder - b.displayOrder);
-    const visibleKscene = [...postTags]
-      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group === K_SCENE_GROUP)
+    const visibleKmedia = [...postTags]
+      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group === K_MEDIA_GROUP)
       .sort((a, b) => a.displayOrder - b.displayOrder);
     const visibleOther = [...postTags]
-      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group !== K_SCENE_GROUP)
+      .filter((pt) => pt.isVisible && tagMap.get(pt.tagId)?.group !== K_MEDIA_GROUP)
       .sort((a, b) => a.displayOrder - b.displayOrder);
 
     const topicSlots: PreviewSlot[] = visibleTopics.map((pt) => {
@@ -308,10 +308,10 @@ export function LabelVisibilityCard({
       };
     });
 
-    const ksceneSlots: PreviewSlot[] = visibleKscene.map((pt) => {
+    const kmediaSlots: PreviewSlot[] = visibleKmedia.map((pt) => {
       const t = tagMap.get(pt.tagId)!;
       const { background, color } = t ? getTagColors(t) : { background: "", color: "#000" };
-      return { group: K_SCENE_GROUP, name: t?.name ?? pt.tagId, displayLabel: null, background, color };
+      return { group: K_MEDIA_GROUP, name: t?.name ?? pt.tagId, displayLabel: null, background, color };
     });
 
     const otherSlots: PreviewSlot[] = visibleOther.map((pt) => {
@@ -321,10 +321,8 @@ export function LabelVisibilityCard({
       return { group: t?.group ?? "OTHER", name: t?.name ?? pt.tagId, displayLabel, background, color };
     });
 
-    const ORDER = (g: string) => g === "TOPIC" ? 0 : g === K_SCENE_GROUP ? 1 : 2;
-
     function applyText(selected: PreviewSlot[]): PreviewLabel[] {
-      selected.sort((a, b) => ORDER(a.group) - ORDER(b.group));
+      selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
       return selected.map((slot) => {
         const hasOtherGroup = selected.some((s) => s.group !== slot.group);
         const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
@@ -344,10 +342,10 @@ export function LabelVisibilityCard({
     const listSelected: PreviewSlot[] = [];
     let lT = 0, lK = 0, lO = 0;
     if (lT < topicSlots.length) listSelected.push(topicSlots[lT++]);
-    if (lK < ksceneSlots.length) listSelected.push(ksceneSlots[lK++]);
+    if (lK < kmediaSlots.length) listSelected.push(kmediaSlots[lK++]);
     if (lO < otherSlots.length) listSelected.push(otherSlots[lO++]);
     if (listSelected.length < 3) {
-      const remaining = [...topicSlots.slice(lT), ...ksceneSlots.slice(lK), ...otherSlots.slice(lO)];
+      const remaining = [...topicSlots.slice(lT), ...kmediaSlots.slice(lK), ...otherSlots.slice(lO)];
       for (const slot of remaining) {
         if (listSelected.length >= 3) break;
         listSelected.push(slot);
@@ -357,7 +355,7 @@ export function LabelVisibilityCard({
     // 상세
     const detailLabels: PreviewLabel[] = [
       ...topicSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
-      ...ksceneSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
+      ...kmediaSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
       ...otherSlots.map((s) => ({ text: s.name, background: s.background, color: s.color })),
     ];
 
@@ -378,10 +376,10 @@ export function LabelVisibilityCard({
     });
   };
 
-  const handleKsceneDragEnd = (event: DragEndEvent) => {
+  const handleKmediaDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const visible = ksceneItems.filter((i) => i.isVisible);
+    const visible = kmediaItems.filter((i) => i.isVisible);
     const oldIdx = visible.findIndex((i) => i.id === active.id);
     const newIdx = visible.findIndex((i) => i.id === over.id);
     if (oldIdx === -1 || newIdx === -1) return;
@@ -427,11 +425,11 @@ export function LabelVisibilityCard({
         {/* ── K-MEDIA 태그 ── */}
         <GroupSection
           title="K-MEDIA 태그"
-          dndId="label-kscene-dnd"
-          items={ksceneItems}
+          dndId="label-kmedia-dnd"
+          items={kmediaItems}
           sensors={sensors}
           onToggle={(id) => setPostTags((prev) => prev.map((pt) => pt.tagId === id ? { ...pt, isVisible: !pt.isVisible } : pt))}
-          onDragEnd={handleKsceneDragEnd}
+          onDragEnd={handleKmediaDragEnd}
         />
 
         {/* ── 나머지 태그 ── */}

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -1086,6 +1086,7 @@ export function PostForm({
                 allTopics={localAllTopics}
                 allTags={localAllTags}
                 topicEffectiveStyleMap={topicEffectiveStyleMap}
+                topicEffectiveInfoMap={topicEffectiveInfoMap}
                 tagGroups={tagGroups}
               />
 

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -90,6 +90,7 @@ export type TopicForForm = {
 export type TagGroupItem = {
   group: string;
   nameEn: string;
+  displayLabel?: string | null;
   colorHex?: string;
   colorHex2?: string | null;
   gradientDir?: string;
@@ -654,7 +655,7 @@ export function PostForm({
       {/* ── 본문 ─────────────────────────────────────────────────────────── */}
       <div className="flex-1 px-6 py-6">
         <div className="mx-auto max-w-[1400px]">
-          <div className="grid grid-cols-[1fr_320px] gap-6 items-start">
+          <div className="grid grid-cols-[1fr_380px] gap-6 items-start">
 
             {/* ── 왼쪽: 제목 카드 + 탭 카드 ───────────────────────────── */}
             <div className="min-w-0 space-y-3">
@@ -1085,6 +1086,7 @@ export function PostForm({
                 allTopics={localAllTopics}
                 allTags={localAllTags}
                 topicEffectiveStyleMap={topicEffectiveStyleMap}
+                tagGroups={tagGroups}
               />
 
               {/* 수집 정보 */}

--- a/src/app/admin/posts/new/page.tsx
+++ b/src/app/admin/posts/new/page.tsx
@@ -20,6 +20,7 @@ export default async function NewPostPage() {
       select: {
         group: true,
         nameEn: true,
+        displayLabel: true,
         colorHex: true,
         colorHex2: true,
         gradientDir: true,
@@ -60,6 +61,7 @@ export default async function NewPostPage() {
   const tagGroups = tagGroupConfigs.map((c) => ({
     group: c.group,
     nameEn: c.nameEn,
+    displayLabel: c.displayLabel,
     colorHex: c.colorHex,
     colorHex2: c.colorHex2,
     gradientDir: c.gradientDir,

--- a/src/lib/post-labels.ts
+++ b/src/lib/post-labels.ts
@@ -128,3 +128,67 @@ export function labelBackground(label: ResolvedLabel): string {
     ? `linear-gradient(${label.gradientDir}, ${label.colorHex}, ${label.colorHex2} ${label.gradientStop}%)`
     : label.colorHex;
 }
+
+// ── 라벨 슬롯 선택 공통 타입 ──────────────────────────────────────────────────
+
+export type LabelSlot = {
+  group: string;
+  name: string;
+  displayLabel: string | null;
+  colors: Omit<ResolvedLabel, "text">;
+};
+
+/** 슬롯 배열을 ResolvedLabel[]로 변환 (정렬 + displayLabel 결정 포함) */
+function finalizeSlots(selected: LabelSlot[]): ResolvedLabel[] {
+  selected.sort((a, b) => labelGroupOrder(a.group) - labelGroupOrder(b.group));
+  return selected.map((slot) => {
+    const hasOtherGroup = selected.some((s) => s.group !== slot.group);
+    const text = slot.displayLabel && hasOtherGroup ? slot.displayLabel : slot.name;
+    return { text, ...slot.colors };
+  });
+}
+
+/**
+ * home variant — 토픽 1 + non-K_MEDIA 태그 1 (최대 2개)
+ * 슬롯이 부족하면 상호 보완
+ */
+export function selectHomeLabels(
+  topicSlots: LabelSlot[],
+  otherSlots: LabelSlot[],
+): ResolvedLabel[] {
+  const selected: LabelSlot[] = [];
+  let topicUsed = 0, otherUsed = 0;
+  if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+  else if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+  if (otherUsed < otherSlots.length) selected.push(otherSlots[otherUsed++]);
+  else if (topicUsed < topicSlots.length) selected.push(topicSlots[topicUsed++]);
+  return finalizeSlots(selected);
+}
+
+/**
+ * list variant — 토픽 1 + K_MEDIA 1 + non-K_MEDIA 1, 최대 3개
+ * 빈 슬롯은 남은 항목으로 보충
+ */
+export function selectListLabels(
+  topicSlots: LabelSlot[],
+  kmediaSlots: LabelSlot[],
+  otherSlots: LabelSlot[],
+): ResolvedLabel[] {
+  const selected: LabelSlot[] = [];
+  let topicUsed = 0, kmediaUsed = 0, otherUsed = 0;
+  if (topicUsed < topicSlots.length)   selected.push(topicSlots[topicUsed++]);
+  if (kmediaUsed < kmediaSlots.length) selected.push(kmediaSlots[kmediaUsed++]);
+  if (otherUsed < otherSlots.length)   selected.push(otherSlots[otherUsed++]);
+  if (selected.length < 3) {
+    const remaining = [
+      ...topicSlots.slice(topicUsed),
+      ...kmediaSlots.slice(kmediaUsed),
+      ...otherSlots.slice(otherUsed),
+    ];
+    for (const slot of remaining) {
+      if (selected.length >= 3) break;
+      selected.push(slot);
+    }
+  }
+  return finalizeSlots(selected);
+}

--- a/src/lib/post-labels.ts
+++ b/src/lib/post-labels.ts
@@ -1,6 +1,13 @@
 // 포스트 라벨 색상 헬퍼 — 홈·탐색 등 여러 페이지에서 공유
 import type React from "react";
 
+/** K-MEDIA 태그 그룹 PK — 변경 시 DB TagGroupConfig.group과 동기화 */
+export const K_MEDIA_GROUP = "K_MEDIA";
+
+/** 라벨 렌더링 그룹 우선순위: 토픽(0) → K-MEDIA(1) → 나머지(2) */
+export const labelGroupOrder = (group: string): number =>
+  group === "TOPIC" ? 0 : group === K_MEDIA_GROUP ? 1 : 2;
+
 export const DEFAULT_COLOR = "#e4e4e7";
 export const DEFAULT_TEXT = "#000000";
 

--- a/src/lib/post-labels.ts
+++ b/src/lib/post-labels.ts
@@ -79,6 +79,7 @@ export function resolveTopicColors(node: ColorNode): {
 export type TagGroupColorMap = Map<
   string,
   {
+    displayLabel: string | null;
     colorHex: string;
     colorHex2: string | null;
     gradientDir: string;


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->
K-SCENE → K-MEDIA 리네이밍 및 유저 노출. 카드 라벨 표시 로직을 3축(토픽/K-MEDIA/나머지 태그) 기반으로 변경하여 짧고 구체적인 라벨이 표시되도록 개선. 관리자 라벨 설정 UI를 3그룹 분리 + 미리보기로 개선.

## 변경 사항
- [x] K-SCENE → K-MEDIA 리네이밍 (nameEn, group PK, FK 전부)
- [x] K-MEDIA isVisible: false → true (Explore 필터 노출)
- [x] TagGroupConfig에 displayLabel 필드 추가 (K-SPOT → "Spot", K-ITEM → "Item")
- [x] Tag 변경: TV Show → Variety, Insta + Tweet → SNS 통합
- [x] PostCard 라벨 로직: 3풀 분리(토픽/K-MEDIA/나머지) + 슬롯 선택 + 렌더링 순서 재정렬
- [x] 홈 배너 라벨 로직 PostCard와 통일
- [x] 상세 페이지 정렬: 토픽(level순) → K-MEDIA → 나머지 태그
- [x] 관리자 라벨 설정: 3그룹 분리(토픽/K-MEDIA/나머지) + 미리보기 추가
- [x] 분류 관리 페이지: displayLabel 표시 + 편집 UI + 활성/비활성 시각 구분

### 데이터 3축

| 축 | 출처 | 예시 |
|---|---|---|
| 토픽 | PostTopic | BTS, Goblin, RM, SUGA |
| K-MEDIA | PostTag (K_MEDIA 그룹) | MV, Drama, Variety, SNS |
| 나머지 태그 | PostTag (그 외 그룹) | Spot, Cafe, Active, Merch |

### 페이지별 표시

| 페이지 | 최대 개수 | 슬롯 선택 규칙 | 렌더링 순서 |
|---|---|---|---|
| 홈 카드/배너 | 2개 | 토픽 대표 1 + 나머지 태그 대표 1 (K-MEDIA 미사용) | 토픽 → 나머지 |
| 목록형 카드 | 3개 | 토픽 대표 1 + K-MEDIA 대표 1 + 나머지 태그 대표 1 | 토픽 → K-MEDIA → 나머지 |
| 상세 페이지 | 전부 | isVisible=true 전부 | 토픽(level순) → K-MEDIA → 나머지 |

- "대표" = 각 그룹 내 displayOrder 최솟값
- 빈 슬롯은 남은 항목(토픽 → K-MEDIA → 나머지 순)으로 보충
- displayLabel: 다른 그룹과 경쟁 시 적용 (K-SPOT → "Spot"), 단독이면 태그 name 그대로

### Before → After 예시

| 포스트 | 홈 Before | 홈 After | 목록 Before | 목록 After |
|---|---|---|---|---|
| BTS 뮤비 촬영지 | [BTS] [Filming Location] | [BTS] [MV] | [BTS] [Filming Location] [Photo Spot] | [BTS] [MV] [Spot] |
| RM 인스타 카페 | [RM] [Photo Spot] | [RM] [SNS] | [RM] [Photo Spot] | [RM] [SNS] [Cafe] |
| SVT 예능 촬영지 | [SVT] [Filming Location] | [SVT] [Variety] | [SVT] [Filming Location] | [SVT] [Variety] [Spot] |

### 관리자 라벨 설정

3그룹(토픽/K-MEDIA/나머지 태그)으로 분리. 각 그룹 내 드래그로 순서 변경. 첫 번째 = 대표.
미리보기에서 홈/목록/상세 결과를 실시간 확인 가능.



## 스크린샷

### 홈 화면

<img width="380" alt="홈 화면" src="https://github.com/user-attachments/assets/68a331e1-615b-490b-8d4d-b26cead965fc" />

> 홈 카드/배너: 토픽 대표 1 + 나머지 태그 대표 1 (K-MEDIA 미사용). displayLabel 적용 (Spot, Item 등).

### Explore 목록형 카드

| K-MEDIA 필터 노출 | MV 태그 포스트 | Variety/Film 태그 포스트 |
|---|---|---|
| <img width="250" alt="필터" src="https://github.com/user-attachments/assets/341a813f-2245-4392-be25-a72fde0c1801" /> | <img width="250" alt="MV" src="https://github.com/user-attachments/assets/6dadc23c-f445-4093-8ea5-dc94dc1e2ce3" /> | <img width="250" alt="Variety" src="https://github.com/user-attachments/assets/0526baad-df34-4231-8704-adcfae22fe04" /> |

| Food/Drama 태그 포스트 | ARIRANG 이벤트 포스트 |
|---|---|
| <img width="380" alt="Food" src="https://github.com/user-attachments/assets/fb635419-d7f3-480b-b469-f5fe8e5ba1f3" /> | <img width="380" alt="ARIRANG" src="https://github.com/user-attachments/assets/0ac6b74d-bf2f-4612-8245-86e5fc4fc267" /> |

> 목록형 카드: 토픽 대표 1 + K-MEDIA 대표 1 + 나머지 태그 대표 1. 렌더링 순서 토픽 → K-MEDIA → 나머지.

### 상세 페이지

| Bukchon Hanok Village | Gwanghwamun Gate | midopa coffee house |
|---|---|---|
| <img width="250" alt="Bukchon" src="https://github.com/user-attachments/assets/5478f8a3-991e-4e68-8e49-034971c9d528" /> | <img width="250" alt="Gwanghwamun" src="https://github.com/user-attachments/assets/c4501523-015b-48fe-ba60-f6984e596392" /> | <img width="250" alt="midopa" src="https://github.com/user-attachments/assets/3d8cf5a5-cb61-4d3d-a273-6df827aaf5a8" /> |

> 상세: 토픽(level순) → K-MEDIA → 나머지 태그. displayLabel 미적용, name 그대로.

### KWANGYA@SEOUL — 관리자 설정 → 상세 → 관련 포스트

| 관리자 라벨 설정 | 상세 페이지 | 관련 포스트 카드 |
|---|---|---|
| <img width="250" alt="관리자" src="https://github.com/user-attachments/assets/83cbe3d4-58f5-48eb-adb5-8a740db1b58e" /> | <img width="390" height="845" alt="Screenshot 2026-04-17 at 11 32 26 PM" src="https://github.com/user-attachments/assets/65f625f1-7b6e-493c-bbcf-7422ac313e0f" />| <img width="381" height="109" alt="image" src="https://github.com/user-attachments/assets/c05f13b9-e145-448a-af9a-198fd719086b" /> |

## 리뷰사항
https://www.notion.so/345909315748800088c6f61a9a5c3242?source=copy_link
노션에 정리해두었으니 참고하십쇼
