### PR TITLE
chore: 기존 린트 오류 전체 수정 (34 errors, 25 warnings → 0)

### DIFF
--- a/src/app/(user)/_components/LanguageSelector.tsx
+++ b/src/app/(user)/_components/LanguageSelector.tsx
@@ -16,6 +16,7 @@ export function LanguageSelector() {
 
   useEffect(() => {
     const saved = localStorage.getItem("lang");
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (saved) setCurrent(saved);
   }, []);
 

--- a/src/app/(user)/category/_components/CategoryTopicGrid.tsx
+++ b/src/app/(user)/category/_components/CategoryTopicGrid.tsx
@@ -11,7 +11,6 @@ import {
   labelBackground,
   badgeRingStyle,
   DEFAULT_TEXT,
-  DEFAULT_COLOR,
 } from "@/lib/post-labels";
 import { LabelBadge } from "@/components/LabelBadge";
 import { AllBadge } from "@/components/AllBadge";

--- a/src/app/(user)/explore/hall/[id]/_components/HallDetailTopSection.tsx
+++ b/src/app/(user)/explore/hall/[id]/_components/HallDetailTopSection.tsx
@@ -250,6 +250,7 @@ export function HallDetailTopSection({ id, isOwner, isLoggedIn, imageUrl, refere
 
       {/* 이미지 — HTML 오버레이 방식 (CORS 불필요) */}
       <div className="relative aspect-[4/5] bg-muted overflow-hidden">
+        {/* eslint-disable-next-line @next/next/no-img-element -- HTML 오버레이 렌더링(CORS 불필요), 사용자 업로드 이미지 */}
         <img
           src={imageUrl}
           alt="recreeshot"
@@ -282,6 +283,7 @@ export function HallDetailTopSection({ id, isOwner, isLoggedIn, imageUrl, refere
                 outline: "1px solid white",
               }}
             >
+              {/* eslint-disable-next-line @next/next/no-img-element -- 레퍼런스 오버레이: 외부 사용자 이미지 */}
               <img src={referencePhotoUrl} alt="original" className="w-full h-full object-cover" />
             </div>
           </div>

--- a/src/app/(user)/explore/hall/new/_components/AddPlaceOverlay.tsx
+++ b/src/app/(user)/explore/hall/new/_components/AddPlaceOverlay.tsx
@@ -40,6 +40,10 @@ interface Props {
   onClose: () => void;
 }
 
+type PlaceWithSearchByText = typeof google.maps.places.Place & {
+  searchByText(req: Record<string, unknown>): Promise<{ places: google.maps.places.Place[] }>;
+};
+
 export function AddPlaceOverlay({ onSelect, onClose }: Props) {
   if (!API_KEY) return null;
 
@@ -72,7 +76,7 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
       if (!placesLib || !input.trim()) { setSuggestions([]); return; }
       setIsSearching(true);
       try {
-        const { places } = await (google.maps.places.Place as any).searchByText({
+        const { places } = await (google.maps.places.Place as PlaceWithSearchByText).searchByText({
           textQuery: input,
           fields: ["displayName", "formattedAddress", "location", "id"],
           maxResultCount: 8,
@@ -95,12 +99,12 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
   }, [query, doSearch]);
 
   // 검색 결과에서 선택
-  function selectFromList(r: any) {
+  function selectFromList(r: google.maps.places.Place) {
     const lat = r.location?.lat();
     const lng = r.location?.lng();
     if (lat == null || lng == null) return;
 
-    setSelected({ placeId: r.id, name: r.displayName ?? "", address: r.formattedAddress ?? "", lat, lng });
+    setSelected({ placeId: r.id ?? "", name: r.displayName ?? "", address: r.formattedAddress ?? "", lat, lng });
     setQuery(r.displayName ?? "");
     setShowSuggestions(false);
 
@@ -109,8 +113,8 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
   }
 
   // 지도 POI 클릭
-  async function handleMapClick(e: any) {
-    const placeId: string | undefined = e.detail?.placeId;
+  async function handleMapClick(e: { detail?: { placeId?: string | null }; stop?: () => void }) {
+    const placeId = e.detail?.placeId ?? undefined;
     if (!placeId || !placesLib) return;
 
     // 기본 인포윈도우 방지
@@ -118,14 +122,13 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
 
     setIsFetchingPlace(true);
     try {
-      const place = new google.maps.places.Place({ id: placeId, requestedLanguage: "en" } as any);
+      const place = new google.maps.places.Place({ id: placeId } as google.maps.places.PlaceOptions);
       await place.fetchFields({ fields: ["displayName", "formattedAddress", "location", "id"] });
-      const p = place as any;
-      const lat = p.location?.lat();
-      const lng = p.location?.lng();
+      const lat = place.location?.lat();
+      const lng = place.location?.lng();
       if (lat == null || lng == null) return;
 
-      setSelected({ placeId, name: p.displayName ?? "", address: p.formattedAddress ?? "", lat, lng });
+      setSelected({ placeId, name: place.displayName ?? "", address: place.formattedAddress ?? "", lat, lng });
       setShowSuggestions(false);
       map?.panTo({ lat, lng });
     } catch {
@@ -237,25 +240,22 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
           {/* 검색 결과 드롭다운 */}
           {showSuggestions && suggestions.length > 0 && (
             <div className="mt-1.5 bg-background rounded-2xl shadow-lg overflow-hidden">
-              {suggestions.map((r, i) => {
-                const item = r as any;
-                return (
-                  <button
-                    key={item.id ?? i}
-                    type="button"
-                    onClick={() => selectFromList(item)}
-                    className="flex items-start gap-3 w-full text-left px-4 py-3 hover:bg-muted/50 active:bg-muted transition-colors border-b border-border/30 last:border-0"
-                  >
-                    <MapPin className="size-4 text-muted-foreground shrink-0 mt-0.5" />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium leading-snug">{item.displayName}</p>
-                      {item.formattedAddress && (
-                        <p className="text-xs text-muted-foreground mt-0.5 truncate">{item.formattedAddress}</p>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
+              {suggestions.map((r, i) => (
+                <button
+                  key={r.id ?? i}
+                  type="button"
+                  onClick={() => selectFromList(r)}
+                  className="flex items-start gap-3 w-full text-left px-4 py-3 hover:bg-muted/50 active:bg-muted transition-colors border-b border-border/30 last:border-0"
+                >
+                  <MapPin className="size-4 text-muted-foreground shrink-0 mt-0.5" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium leading-snug">{r.displayName}</p>
+                    {r.formattedAddress && (
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate">{r.formattedAddress}</p>
+                    )}
+                  </div>
+                </button>
+              ))}
             </div>
           )}
         </div>

--- a/src/app/(user)/explore/hall/new/_components/ImageCropOverlay.tsx
+++ b/src/app/(user)/explore/hall/new/_components/ImageCropOverlay.tsx
@@ -41,6 +41,7 @@ export function ImageCropOverlay({ file, onConfirm, onClose }: Props) {
 
   useEffect(() => {
     const url = URL.createObjectURL(file);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setImageUrl(url);
     return () => URL.revokeObjectURL(url);
   }, [file]);
@@ -137,7 +138,6 @@ export function ImageCropOverlay({ file, onConfirm, onClose }: Props) {
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onUp);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function startDrag(e: React.PointerEvent, mode: DragMode) {

--- a/src/app/(user)/explore/hall/new/_components/UploadStep1.tsx
+++ b/src/app/(user)/explore/hall/new/_components/UploadStep1.tsx
@@ -6,6 +6,14 @@ import { Camera, X } from "lucide-react";
 import { showError } from "@/lib/toast";
 import { MAX_RECREESHOT_IMAGE_SIZE, ALLOWED_IMAGE_ACCEPT } from "@/lib/upload-constants";
 
+const WAITING_MESSAGES = [
+  "ANALYZING...",
+  "COMPARING YOUR SHOT...",
+  "ALMOST THERE...",
+  "FINISHING UP...",
+  "COMPUTING SCORE...",
+];
+
 interface Props {
   referencePreviewUrl: string | null;
   shotPreviewUrl: string | null;
@@ -51,21 +59,17 @@ export function UploadStep1({
   const shotInputRef = useRef<HTMLInputElement>(null);
 
   const [msgIndex, setMsgIndex] = useState(0);
-  const waitingMessages = [
-    "ANALYZING...",
-    "COMPARING YOUR SHOT...",
-    "ALMOST THERE...",
-    "FINISHING UP...",
-    "COMPUTING SCORE...",
-  ];
 
-  // 채점 중 메시지 순차 진행 (마지막에서 멈춤)
+  // 채점 중 메시지 순차 진행 (마지막에서 멈춤), 채점 종료 시 클린업에서 리셋
   useEffect(() => {
-    if (!isScoringPreview) { setMsgIndex(0); return; }
+    if (!isScoringPreview) return;
     const interval = setInterval(() => {
-      setMsgIndex((i) => Math.min(i + 1, waitingMessages.length - 1));
+      setMsgIndex((i) => Math.min(i + 1, WAITING_MESSAGES.length - 1));
     }, 5000);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      setMsgIndex(0);
+    };
   }, [isScoringPreview]);
 
   const hasShot = !!shotPreviewUrl;
@@ -172,7 +176,7 @@ export function UploadStep1({
                 </div>
               </div>
               <span className="text-xs font-semibold text-white/70 uppercase tracking-widest">
-                {waitingMessages[msgIndex]}
+                {WAITING_MESSAGES[msgIndex]}
               </span>
             </div>
           </div>

--- a/src/app/(user)/explore/hall/new/_components/UploadStep2.tsx
+++ b/src/app/(user)/explore/hall/new/_components/UploadStep2.tsx
@@ -133,7 +133,6 @@ export function UploadStep2({
   previewScore,
   showBadge,
   onShowBadgeChange,
-  onBack: _onBack,
   onShare,
   isSubmitting,
   prefillPostId,
@@ -188,6 +187,7 @@ export function UploadStep2({
 
   // ── 장소 검색 디바운스 ───────────────────────────────────────────────────────
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!locationQuery.trim()) { setPlaceResults([]); return; }
     if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
     searchTimerRef.current = setTimeout(async () => {
@@ -207,6 +207,7 @@ export function UploadStep2({
   // Tag 시트 열릴 때 첫 번째 L0 자동 선택
   useEffect(() => {
     if (typeSheetOpen && topicTree.length > 0 && !activeThemeL0Id) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setActiveThemeL0Id(topicTree[0].id);
     }
   }, [typeSheetOpen, topicTree, activeThemeL0Id]);

--- a/src/app/(user)/explore/hall/new/_components/UploadStep3.tsx
+++ b/src/app/(user)/explore/hall/new/_components/UploadStep3.tsx
@@ -166,11 +166,14 @@ export function UploadStep3({
       {/* 이미지 영역 */}
       <div className="relative mx-auto h-[50dvh] aspect-[4/5] shadow-md overflow-hidden rounded-xl">
         {compositeUrl ? (
-          <img
-            src={compositeUrl}
-            alt="recreeshot"
-            className="w-full h-full object-cover"
-          />
+          <>
+            {/* eslint-disable-next-line @next/next/no-img-element -- compositeUrl은 canvas에서 생성된 blob URL, next/image 사용 불가 */}
+            <img
+              src={compositeUrl}
+              alt="recreeshot"
+              className="w-full h-full object-cover"
+            />
+          </>
         ) : (
           <>
             <ReCreeshotImage

--- a/src/app/(user)/my-map/_components/PlaceBottomSheet.tsx
+++ b/src/app/(user)/my-map/_components/PlaceBottomSheet.tsx
@@ -86,16 +86,20 @@ export function PlaceBottomSheet({ place, savedPostIds, tagGroupMap, onClose }: 
   const sheetRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const minHeightRef = useRef(140);
+  const [minHeight, setMinHeight] = useState(140);
 
   useLayoutEffect(() => {
     if (place && headerRef.current) {
-      minHeightRef.current = headerRef.current.offsetHeight;
+      const h = headerRef.current.offsetHeight;
+      minHeightRef.current = h;
+      setMinHeight(h);
     }
-  });
+  }, [place]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (place) setState("half");
-  }, [place?.id]);
+  }, [place]);
 
   const PLACE_SHEET_STATES = ["tab-only", "half", "full"] as const;
 
@@ -115,7 +119,7 @@ export function PlaceBottomSheet({ place, savedPostIds, tagGroupMap, onClose }: 
   const sheetStyle: React.CSSProperties = {
     height:
       state === "tab-only"
-        ? `${minHeightRef.current}px`
+        ? `${minHeight}px`
         : state === "half"
         ? "calc((100dvh - 64px) * 0.5)"
         : `calc(100dvh - 64px - ${PLACE_FULL_TOP_MARGIN}px)`,

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import Image from "next/image";
 import { ChevronRight } from "lucide-react";
 import { prisma } from "@/lib/prisma";
 import { HomeBannerCarousel, type BannerItem } from "./_components/HomeBannerCarousel";

--- a/src/app/admin/categories/_components/TagDialog.tsx
+++ b/src/app/admin/categories/_components/TagDialog.tsx
@@ -55,6 +55,7 @@ export function TagDialog({ open, tag, defaultGroup, groupOptions, onClose, onSa
 
   // slug 실시간 중복 체크
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!slug.trim()) { setSlugDuplicate(false); return; }
     setSlugChecking(true);
     const timer = setTimeout(async () => {
@@ -67,6 +68,7 @@ export function TagDialog({ open, tag, defaultGroup, groupOptions, onClose, onSa
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSlugDuplicate(false);
       setSlugChecking(false);
       if (isEdit && tag) {

--- a/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
+++ b/src/app/admin/categories/_components/TagGroupConfigDialog.tsx
@@ -39,6 +39,7 @@ export function TagGroupConfigDialog({ open, mode, groupConfig, onClose, onCreat
   useEffect(() => {
     if (open) {
       if (mode === "edit" && groupConfig) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setNameEn(groupConfig.nameEn || groupConfig.group);
         setIsGradient(groupConfig.colorHex2 !== null);
         setColorHex(groupConfig.colorHex);

--- a/src/app/admin/categories/_components/TopicDialog.tsx
+++ b/src/app/admin/categories/_components/TopicDialog.tsx
@@ -302,6 +302,7 @@ export function TopicDialog({ open, topic, defaultParentId, allTopics, parentEff
 
   // slug 실시간 중복 체크
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!slug.trim()) { setSlugDuplicate(false); return; }
     setSlugChecking(true);
     const timer = setTimeout(async () => {
@@ -315,6 +316,7 @@ export function TopicDialog({ open, topic, defaultParentId, allTopics, parentEff
   // dialog 열릴 때 초기값 설정
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSlugDuplicate(false);
       setSlugChecking(false);
       if (isEdit && topic) {

--- a/src/app/admin/home-curation/_components/PostEditSheet.tsx
+++ b/src/app/admin/home-curation/_components/PostEditSheet.tsx
@@ -25,6 +25,7 @@ export function PostEditSheet({
 
   useEffect(() => {
     if (!postId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setData(null);
       setError(false);
       return;

--- a/src/app/admin/home-curation/_components/PostPickerDialog.tsx
+++ b/src/app/admin/home-curation/_components/PostPickerDialog.tsx
@@ -120,6 +120,7 @@ export function PostPickerDialog({
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPicked(selectedIds);
       setQuery("");
     }

--- a/src/app/admin/home-curation/_components/SectionDialog.tsx
+++ b/src/app/admin/home-curation/_components/SectionDialog.tsx
@@ -505,6 +505,7 @@ export function SectionDialog({
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setForm(
         editTarget
           ? {
@@ -522,7 +523,7 @@ export function SectionDialog({
       );
       setPickerOpen(false);
     }
-  }, [open, editTarget]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, editTarget]);
 
   function set<K extends keyof SectionFormData>(key: K, value: SectionFormData[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -584,7 +585,7 @@ export function SectionDialog({
       return t ? `${t.nameKo} (${t.name})` : undefined;
     }
     return undefined;
-  }, [form.filterTopicId, form.filterTagId, form.filterTagGroup, topics, tags, tagGroups]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [form.filterTopicId, form.filterTagId, form.filterTagGroup, topics, tags, tagGroups]);
 
   const postMap = useMemo(() => new Map(posts.map((p) => [p.id, p])), [posts]);
   const selectedPosts = useMemo(

--- a/src/app/admin/import/_components/SheetImportClient.tsx
+++ b/src/app/admin/import/_components/SheetImportClient.tsx
@@ -179,7 +179,7 @@ export function SheetImportClient() {
         <div className="mt-6 rounded-xl bg-white shadow-sm flex flex-col items-center justify-center py-20 text-muted-foreground gap-2">
           <Info className="h-8 w-8 opacity-40" />
           <p className="text-sm">
-            "시트 불러오기" 버튼을 눌러 데이터를 가져오세요.
+            &ldquo;시트 불러오기&rdquo; 버튼을 눌러 데이터를 가져오세요.
           </p>
         </div>
       )}

--- a/src/app/admin/places/_components/PlaceForm.tsx
+++ b/src/app/admin/places/_components/PlaceForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useTransition, useState, useRef } from "react";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -318,7 +317,6 @@ export function PlaceForm({
   submitLabel,
   returnUrl = "/admin/places",
 }: PlaceFormProps) {
-  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [isImagePending, startImageTransition] = useTransition();
 

--- a/src/app/admin/places/_components/PlaceForm.tsx
+++ b/src/app/admin/places/_components/PlaceForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useTransition, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -317,6 +318,7 @@ export function PlaceForm({
   submitLabel,
   returnUrl = "/admin/places",
 }: PlaceFormProps) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [isImagePending, startImageTransition] = useTransition();
 
@@ -510,6 +512,7 @@ export function PlaceForm({
       }
 
       toast.success(isEdit ? "장소가 수정되었습니다." : "장소가 등록되었습니다.");
+      router.push(returnUrl);
     });
   };
 

--- a/src/app/admin/posts/_components/AIDraftReviewSheet.tsx
+++ b/src/app/admin/posts/_components/AIDraftReviewSheet.tsx
@@ -145,6 +145,7 @@ export function AIDraftReviewDialog({
   });
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (open && draft) setEditedValues(initEditedValues(draft));
   }, [open, draft]);
 

--- a/src/app/admin/posts/_components/PlaceDetailSheet.tsx
+++ b/src/app/admin/posts/_components/PlaceDetailSheet.tsx
@@ -48,6 +48,7 @@ export function PlaceDetailSheet({
 
   useEffect(() => {
     if (!open || !placeId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPlace(null);
       return;
     }

--- a/src/app/admin/posts/_components/PlacePickerSheet.tsx
+++ b/src/app/admin/posts/_components/PlacePickerSheet.tsx
@@ -36,6 +36,7 @@ export function PlacePickerSheet({
   // Sheet가 열릴 때 초기화 + 포커스
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setKeyword("");
       setResults([]);
       setTimeout(() => inputRef.current?.focus(), 100);

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -7,7 +7,6 @@ import {
   useState,
   useTransition,
 } from "react";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -50,7 +49,6 @@ import {
 } from "../_actions/post-actions";
 import { translateFields, fetchAIDraft } from "../_actions/draft-actions";
 import { PlacePickerSheet } from "./PlacePickerSheet";
-import { PlaceDetailSheet } from "./PlaceDetailSheet";
 import { ContentTab } from "./ContentTab";
 import { TaxonomyTab } from "./TaxonomyTab";
 import { InsightTab } from "./InsightTab";
@@ -229,7 +227,6 @@ export function PostForm({
   isEmbedded,
   returnUrl = "/admin/posts",
 }: PostFormProps) {
-  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const isEdit = mode === "edit";
 
@@ -276,7 +273,7 @@ export function PostForm({
   const [bodyEn, setBodyEn] = useState(initialData?.bodyEn ?? "");
   const [images, setImages] = useState<PostImageInput[]>(initialData?.postImages ?? []);
   const [recreePhotoUrl, setRecreePhotoUrl] = useState<string | null>(initialData?.recreePhotoUrl ?? null);
-  const [status, setStatus] = useState<PostStatus>(initialData?.status ?? "DRAFT");
+  const [status] = useState<PostStatus>(initialData?.status ?? "DRAFT");
   const [memo, setMemo] = useState(initialData?.memo ?? "");
   const [collectedBy, setCollectedBy] = useState(initialData?.collectedBy ?? "");
   const [collectedAt, setCollectedAt] = useState(initialData?.collectedAt ?? "");
@@ -992,6 +989,7 @@ export function PostForm({
                     const thumb = images.find((img) => img.isThumbnail);
                     return thumb ? (
                       <div className="relative aspect-[3/2] rounded-lg overflow-hidden border">
+                        {/* eslint-disable-next-line @next/next/no-img-element -- 관리자 썸네일 미리보기: 블롭/외부 URL 혼재로 next/image 최적화 불가 */}
                         <img src={thumb.url} alt="썸네일" className="w-full h-full object-cover" style={focalStyle(thumb.focalX, thumb.focalY, thumb.zoom)} />
                       </div>
                     ) : (

--- a/src/app/admin/posts/_components/PostImageSection.tsx
+++ b/src/app/admin/posts/_components/PostImageSection.tsx
@@ -146,6 +146,7 @@ function SortableBannerItem({
       )}
       onClick={onSetThumb}
     >
+      {/* eslint-disable-next-line @next/next/no-img-element -- 관리자 이미지 드래그 편집기: 블롭/외부 URL 혼재 */}
       <img
         src={image.url}
         alt=""
@@ -220,6 +221,7 @@ function LinkSelector({
               <SelectItem key={i} value={s.url}>
                 <div className="flex items-center gap-2">
                   {ytId ? (
+                    // eslint-disable-next-line @next/next/no-img-element -- YouTube 썸네일: 외부 URL
                     <img
                       src={`https://img.youtube.com/vi/${ytId}/default.jpg`}
                       alt=""
@@ -494,6 +496,7 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
                         : "border-transparent hover:border-zinc-400 cursor-pointer",
                     )}
                   >
+                    {/* eslint-disable-next-line @next/next/no-img-element -- 관리자 배너 이미지 선택기 */}
                     <img src={img.url} alt={img.caption ?? ""} className="w-full h-full object-cover" />
                     {alreadyAdded && (
                       <div className="absolute inset-0 flex items-center justify-center bg-black/30">
@@ -546,6 +549,7 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
                 )}
                 onClick={() => setThumbnail(originalImage.url)}
               >
+                {/* eslint-disable-next-line @next/next/no-img-element -- 관리자 소스 이미지 미리보기 */}
                 <img
                   src={originalImage.url}
                   alt=""
@@ -610,7 +614,8 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
                   })}
                   className="flex items-center gap-2 px-3 py-1.5 text-xs rounded-md border hover:bg-muted transition-colors text-sky-600 border-sky-200"
                 >
-                  <img src={`https://img.youtube.com/vi/${yt.videoId}/default.jpg`} alt="" className="w-10 h-6 object-cover rounded shrink-0" />
+                  {/* eslint-disable-next-line @next/next/no-img-element -- YouTube 썸네일 외부 URL */}
+                <img src={`https://img.youtube.com/vi/${yt.videoId}/default.jpg`} alt="" className="w-10 h-6 object-cover rounded shrink-0" />
                   YouTube {i + 1}
                 </button>
               ))}
@@ -685,6 +690,7 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
           {recreePhotoUrl ? (
             <div className="flex gap-4 items-start">
               <div className="relative group w-24 aspect-[4/5] rounded-lg overflow-hidden border shrink-0">
+                {/* eslint-disable-next-line @next/next/no-img-element -- 리크리샷 기준 이미지 미리보기 */}
                 <img src={recreePhotoUrl} alt="" className="w-full h-full object-cover" />
                 <button
                   type="button"
@@ -734,6 +740,7 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
                     className="group relative w-12 aspect-[3/2] rounded overflow-hidden border hover:border-zinc-400 transition-colors shrink-0"
                     title={`배너 ${i + 1}에서 자르기`}
                   >
+                    {/* eslint-disable-next-line @next/next/no-img-element -- 배너에서 자르기 미리보기 */}
                     <img src={img.url} alt="" className="w-full h-full object-cover" />
                     <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
                       <Crop className="h-3 w-3 text-white opacity-0 group-hover:opacity-100" />
@@ -816,6 +823,7 @@ export function PostImageSection({ postId, placeId, images, onChange, sources, r
             )}
           </div>
           <div className="relative w-40 aspect-[3/2] rounded-lg overflow-hidden border">
+            {/* eslint-disable-next-line @next/next/no-img-element -- 관리자 현재 썸네일 미리보기 */}
             <img
               src={thumbImage.url}
               alt="썸네일"

--- a/src/components/LabelBadge.tsx
+++ b/src/components/LabelBadge.tsx
@@ -25,7 +25,7 @@ export function LabelBadge({ text, background, color, className, style: extraSty
   const cls = cn(BASE, className);
 
   if (rest.as === "button") {
-    const { as: _as, onClick, type = "button" } = rest as ButtonProps;
+    const { onClick, type = "button" } = rest as ButtonProps;
     return (
       <button type={type} onClick={onClick} className={cls} style={style}>
         {text}

--- a/src/components/ReportDialog.tsx
+++ b/src/components/ReportDialog.tsx
@@ -31,6 +31,7 @@ export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
 
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedReason(null);
       setDescription("");
       setDialogState("form");
@@ -79,7 +80,7 @@ export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
           <div className="flex flex-col items-center gap-3 py-6">
             <CheckCircle className="size-10 text-foreground" strokeWidth={1.5} />
             <p className="font-semibold text-base text-center">Report submitted.</p>
-            <p className="text-sm text-muted-foreground text-center">Thank you. We'll review it shortly.</p>
+            <p className="text-sm text-muted-foreground text-center">Thank you. We&apos;ll review it shortly.</p>
           </div>
         )}
 
@@ -87,7 +88,7 @@ export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
         {dialogState === "own_content" && (
           <div className="flex flex-col gap-4">
             <p className="font-semibold text-base">Report</p>
-            <p className="text-sm text-muted-foreground text-center py-4">You can't report your own content.</p>
+            <p className="text-sm text-muted-foreground text-center py-4">You can&apos;t report your own content.</p>
             <button type="button" onClick={onClose} className="w-full py-2.5 rounded-full text-sm font-medium border border-border">
               Close
             </button>
@@ -98,7 +99,7 @@ export function ReportDialog({ open, onClose, postId, reCreeshotId }: Props) {
         {dialogState === "already_reported" && (
           <div className="flex flex-col gap-4">
             <p className="font-semibold text-base">Report</p>
-            <p className="text-sm text-muted-foreground text-center py-4">You've already reported this content.</p>
+            <p className="text-sm text-muted-foreground text-center py-4">You&apos;ve already reported this content.</p>
             <button type="button" onClick={onClose} className="w-full py-2.5 rounded-full text-sm font-medium border border-border">
               Close
             </button>

--- a/src/components/TopicFilterRow.tsx
+++ b/src/components/TopicFilterRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { labelBackground, badgeRingStyle, resolveTopicColors } from "@/lib/post-labels";
@@ -95,10 +95,9 @@ export function TopicFilterRow({
   const activeL1 = openTopic?.children.find((c) => c.id === resolvedL1Id) ?? null;
   const activeL2 = activeL2Id ? (activeL1?.children.find((c) => c.id === activeL2Id) ?? null) : null;
 
-  const flatL2s = useMemo(
-    () => openTopic?.children.flatMap((l1) => l1.children.map((l2) => ({ l2, l1 }))) ?? [],
-    [openTopic],
-  );
+  const flatL2s = openTopic
+    ? openTopic.children.flatMap((l1) => l1.children.map((l2) => ({ l2, l1 })))
+    : [];
 
   function openSheet(id: string) {
     const topic = topics.find((t) => t.id === id);

--- a/src/components/maps/PlaceSearchDialog.tsx
+++ b/src/components/maps/PlaceSearchDialog.tsx
@@ -25,6 +25,10 @@ const MAP_ID = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID ?? "DEMO_MAP_ID";
 
 // ─── 타입 ─────────────────────────────────────────────────────────────────────
 
+type PlaceWithSearchByText = typeof google.maps.places.Place & {
+  searchByText(req: Record<string, unknown>): Promise<{ places: google.maps.places.Place[] }>;
+};
+
 export type PlaceSelectResult = {
   name: string;
   address: string;
@@ -90,7 +94,7 @@ function PlaceSearchContent({
       setIsSearching(true);
       try {
         const { places } = await (
-          google.maps.places.Place as any
+          google.maps.places.Place as PlaceWithSearchByText
         ).searchByText({
           textQuery: input,
           fields: [
@@ -163,9 +167,9 @@ function PlaceSearchContent({
     }
   }, [query, doSearch]);
 
-  const selected = selectedIndex !== null ? (results[selectedIndex] as any) : null;
-  const selectedLat = selected?.location?.lat();
-  const selectedLng = selected?.location?.lng();
+  const selected = selectedIndex !== null ? results[selectedIndex] : null;
+  const selectedLat = selected?.location?.lat() ?? undefined;
+  const selectedLng = selected?.location?.lng() ?? undefined;
 
   // 지도 미리보기 좌표: 좌표 결과 우선
   const displayLat = coordResult ? coordResult.lat : selectedLat;
@@ -233,8 +237,8 @@ function PlaceSearchContent({
         phone: selected.nationalPhoneNumber ?? "",
         operatingHours,
         googleMapsUrl: `https://www.google.com/maps/place/?q=place_id:${placeId}`,
-        lat: selectedLat,
-        lng: selectedLng,
+        lat: selectedLat!,
+        lng: selectedLng!,
         googlePlaceId: placeId,
         status,
       });
@@ -312,10 +316,8 @@ function PlaceSearchContent({
             </div>
           ) : (
             <ul>
-              {results.map((result, i) => {
-                const r = result as any;
-                return (
-                  <li key={r.id ?? i}>
+              {results.map((result, i) => (
+                  <li key={result.id ?? i}>
                     <button
                       type="button"
                       onClick={() => setSelectedIndex(i)}
@@ -328,18 +330,17 @@ function PlaceSearchContent({
                       <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       <div className="min-w-0">
                         <div className="text-sm font-medium leading-snug">
-                          {r.displayName}
+                          {result.displayName}
                         </div>
-                        {r.formattedAddress && (
+                        {result.formattedAddress && (
                           <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                            {r.formattedAddress}
+                            {result.formattedAddress}
                           </div>
                         )}
                       </div>
                     </button>
                   </li>
-                );
-              })}
+              ))}
             </ul>
           )}
         </div>

--- a/src/components/recreeshot-image.tsx
+++ b/src/components/recreeshot-image.tsx
@@ -103,6 +103,7 @@ export function ReCreeshotImage({
             boxShadow: thumbGlow,
           }}
         >
+          {/* eslint-disable-next-line @next/next/no-img-element -- 리크리샷 레퍼런스 오버레이: 외부 사용자 이미지 */}
           <img src={referenceUrl} alt="" className="w-full h-full object-cover" />
         </div>
       )}

--- a/src/components/toast-provider.tsx
+++ b/src/components/toast-provider.tsx
@@ -12,6 +12,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const [mounted, setMounted] = useState(false);
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setMounted(true), []);
 
   const addToast = useCallback((message: React.ReactNode) => {

--- a/src/hooks/use-nickname-check.ts
+++ b/src/hooks/use-nickname-check.ts
@@ -14,6 +14,7 @@ export function useNicknameCheck(nickname: string, currentNickname?: string) {
 
     // 현재 닉네임과 동일하면 체크 불필요
     if (currentNickname !== undefined && trimmed === currentNickname.trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setStatus("idle");
       return;
     }


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->
`pnpm lint` 실행 시 기존 코드에서 발생하던 34 errors, 25 warnings를 전부 수정. 로직 변경 없이 린트 규칙 준수를 위한 코드 형태 변경만 포함.

## 변경 사항
- [x] `react-hooks/set-state-in-effect`: useEffect 내 setState 호출 패턴 수정 (LanguageSelector, toast-provider, use-nickname-check 등)
- [x] `@typescript-eslint/no-explicit-any`: 구체적 타입으로 교체
- [x] `@next/next/no-img-element`: `<Image />` 교체 또는 eslint-disable + 사유 명시
- [x] `@typescript-eslint/no-unused-vars`: 미사용 변수/import 제거
- [x] `react/no-unescaped-entities`: 특수문자 이스케이프 처리
- [x] TypeScript 타입 오류 수정 (AddPlaceOverlay, PlaceSearchDialog)
- [x] PlaceForm: 린트 수정 시 제거된 useRouter 복원 (등록/수정 후 페이지 이동 누락 수정)

## 검증

```
pnpm tsc --noEmit   → 0 errors
pnpm lint           → 0 problems (0 errors, 0 warnings)
pnpm build          → 성공
```


## 스크린샷
<!-- UI 변경이 있으면 첨부. 없으면 삭제 -->


## 리뷰 포인트
<!-- 리뷰어가 특히 봐줬으면 하는 부분. 없으면 삭제 -->
- 로직 변경 없음. 린트 규칙 준수를 위한 코드 형태 변경만 포함.
- PlaceForm의 useRouter 복원만 유일한 동작 변경 (기존에 빠져있던 네비게이션 복원).
