### PR TITLE
fix: 구글맵 URL을 공식 Maps URL API 포맷으로 변경

### DIFF
--- a/scripts/migrate-google-maps-url.ts
+++ b/scripts/migrate-google-maps-url.ts
@@ -1,0 +1,72 @@
+/**
+ * 기존 DB에 저장된 비공식 구글맵 URL을 공식 Google Maps URL API 포맷으로 마이그레이션
+ *
+ * 변환: https://www.google.com/maps/place/?q=place_id:XXX
+ *    → https://www.google.com/maps/search/?api=1&query=NAME&query_place_id=XXX
+ *
+ * 실행 (dry-run):  pnpm ts-node --compiler-options '{"module":"CommonJS"}' scripts/migrate-google-maps-url.ts
+ * 실행 (실제 적용): pnpm ts-node --compiler-options '{"module":"CommonJS"}' scripts/migrate-google-maps-url.ts --apply
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+process.loadEnvFile(".env.local");
+
+const isDryRun = !process.argv.includes("--apply");
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+const OLD_PATTERN = "https://www.google.com/maps/place/?q=place_id:";
+
+async function main() {
+  console.log(`\n${isDryRun ? "🔍 DRY-RUN (변경 없음)" : "✏️  APPLY (실제 변경)"}\n`);
+
+  const places = await prisma.place.findMany({
+    where: { googleMapsUrl: { startsWith: OLD_PATTERN } },
+    select: { id: true, nameEn: true, nameKo: true, googleMapsUrl: true, googlePlaceId: true },
+  });
+
+  console.log(`대상 레코드: ${places.length}건\n`);
+  if (places.length === 0) {
+    console.log("마이그레이션할 데이터가 없습니다.");
+    return;
+  }
+
+  const updates: { id: string; old: string; new: string }[] = [];
+
+  for (const place of places) {
+    const oldUrl = place.googleMapsUrl!;
+    const placeId = place.googlePlaceId ?? oldUrl.replace(OLD_PATTERN, "");
+    const name = place.nameEn || place.nameKo || "";
+    const newUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name)}&query_place_id=${placeId}`;
+    updates.push({ id: place.id, old: oldUrl, new: newUrl });
+  }
+
+  for (const u of updates) {
+    console.log(`ID: ${u.id}`);
+    console.log(`  기존: ${u.old}`);
+    console.log(`  변경: ${u.new}\n`);
+  }
+
+  if (isDryRun) {
+    console.log("👆 위 내용으로 변경됩니다. 적용하려면 --apply 플래그를 추가하세요.");
+    return;
+  }
+
+  let successCount = 0;
+  for (const u of updates) {
+    await prisma.place.update({
+      where: { id: u.id },
+      data: { googleMapsUrl: u.new },
+    });
+    successCount++;
+  }
+
+  console.log(`✅ ${successCount}건 업데이트 완료`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/scripts/migrate-street-view-url.ts
+++ b/scripts/migrate-street-view-url.ts
@@ -1,0 +1,107 @@
+/**
+ * 기존 DB의 순수 Street View URL을 공식 Google Maps URL API 포맷으로 마이그레이션
+ *
+ * 변환 대상: /@lat,lng,Xa,... 형태의 순수 Street View URL
+ * 변환 제외: /place/ 경로가 있는 포토뷰어 URL (앱에서 정상 작동)
+ * 변환 제외: 이미 map_action=pano 포맷인 URL
+ *
+ * 변환 결과: https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=LAT,LNG
+ *
+ * 실행 (dry-run):  pnpm ts-node --compiler-options '{"module":"CommonJS"}' scripts/migrate-street-view-url.ts
+ * 실행 (실제 적용): pnpm ts-node --compiler-options '{"module":"CommonJS"}' scripts/migrate-street-view-url.ts --apply
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { resolveGoogleMapsUrl, expandGoogleMapsShortUrl, buildStreetViewUrl } from "../src/lib/google-maps-url";
+
+process.loadEnvFile(".env.local");
+
+const isDryRun = !process.argv.includes("--apply");
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  console.log(`\n${isDryRun ? "🔍 DRY-RUN (변경 없음)" : "✏️  APPLY (실제 변경)"}\n`);
+
+  const places = await prisma.place.findMany({
+    where: { streetViewUrl: { not: null } },
+    select: { id: true, nameEn: true, streetViewUrl: true, latitude: true, longitude: true },
+  });
+
+  console.log(`Street View URL이 있는 장소: ${places.length}건\n`);
+
+  const updates: { id: string; old: string; new: string }[] = [];
+  const skipped: { id: string; url: string; reason: string }[] = [];
+
+  for (const place of places) {
+    const url = place.streetViewUrl!;
+
+    if (url.includes("map_action=pano")) {
+      skipped.push({ id: place.id, url, reason: "이미 공식 포맷" });
+      continue;
+    }
+    if (url.includes("/place/")) {
+      skipped.push({ id: place.id, url, reason: "포토뷰어 URL (변환 불필요)" });
+      continue;
+    }
+
+    // 단축 URL 확장 후 좌표 추출
+    const expanded = await expandGoogleMapsShortUrl(url);
+    const resolved = await resolveGoogleMapsUrl(expanded);
+
+    let lat: number | null = null;
+    let lng: number | null = null;
+
+    if (resolved?.type === "streetview" && resolved.lat && resolved.lng) {
+      lat = resolved.lat;
+      lng = resolved.lng;
+    } else if (place.latitude && place.longitude) {
+      // 파싱 실패 시 장소 좌표로 fallback
+      lat = Number(place.latitude);
+      lng = Number(place.longitude);
+    }
+
+    if (lat && lng) {
+      updates.push({ id: place.id, old: url, new: buildStreetViewUrl(lat, lng) });
+    } else {
+      skipped.push({ id: place.id, url, reason: "좌표 추출 실패 (수동 확인 필요)" });
+    }
+  }
+
+  console.log(`변환 대상: ${updates.length}건`);
+  console.log(`건너뜀: ${skipped.length}건\n`);
+
+  if (updates.length > 0) {
+    console.log("── 변환 대상 ──────────────────────────────────────────");
+    for (const u of updates) {
+      console.log(`ID: ${u.id}`);
+      console.log(`  기존: ${u.old}`);
+      console.log(`  변경: ${u.new}\n`);
+    }
+  }
+
+  if (skipped.length > 0) {
+    console.log("── 건너뜀 ─────────────────────────────────────────────");
+    for (const s of skipped) {
+      console.log(`ID: ${s.id} (${s.reason})`);
+      console.log(`  URL: ${s.url}\n`);
+    }
+  }
+
+  if (isDryRun) {
+    console.log("👆 위 내용으로 변경됩니다. 적용하려면 --apply 플래그를 추가하세요.");
+    return;
+  }
+
+  for (const u of updates) {
+    await prisma.place.update({ where: { id: u.id }, data: { streetViewUrl: u.new } });
+  }
+
+  console.log(`✅ ${updates.length}건 업데이트 완료`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/app/(user)/explore/hall/new/_components/AddPlaceOverlay.tsx
+++ b/src/app/(user)/explore/hall/new/_components/AddPlaceOverlay.tsx
@@ -164,7 +164,7 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
         lat: selected.lat,
         lng: selected.lng,
         googlePlaceId: selected.placeId,
-        googleMapsUrl: `https://www.google.com/maps/place/?q=place_id:${selected.placeId}`,
+        googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.name)}&query_place_id=${selected.placeId}`,
       });
 
       if ("error" in result) { alert(result.error); return; }

--- a/src/app/(user)/explore/hall/new/_components/AddPlaceOverlay.tsx
+++ b/src/app/(user)/explore/hall/new/_components/AddPlaceOverlay.tsx
@@ -10,6 +10,7 @@ import {
   useMap,
 } from "@vis.gl/react-google-maps";
 import { createPlaceFromGoogleMaps } from "@/app/(user)/_actions/recreeshot-actions";
+import { buildMapsUrlByPlaceId } from "@/lib/google-maps-url";
 
 const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
 const MAP_ID = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID ?? "DEMO_MAP_ID";
@@ -164,7 +165,7 @@ function AddPlaceContent({ onSelect, onClose }: Props) {
         lat: selected.lat,
         lng: selected.lng,
         googlePlaceId: selected.placeId,
-        googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.name)}&query_place_id=${selected.placeId}`,
+        googleMapsUrl: buildMapsUrlByPlaceId(selected.name, selected.placeId),
       });
 
       if ("error" in result) { alert(result.error); return; }

--- a/src/app/admin/import/_actions/import-actions.ts
+++ b/src/app/admin/import/_actions/import-actions.ts
@@ -3,7 +3,7 @@
 import Papa from "papaparse";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { expandGoogleMapsShortUrl, resolveGoogleMapsUrl, buildStreetViewUrl } from "@/lib/google-maps-url";
+import { expandGoogleMapsShortUrl, resolveGoogleMapsUrl, buildStreetViewUrl, buildMapsUrlByCoords } from "@/lib/google-maps-url";
 import { detectPlatform } from "@/lib/platform";
 import type { SourceType } from "@prisma/client";
 
@@ -470,7 +470,7 @@ export async function importSheetRows(rowIds: string[]): Promise<{
 
       // google_maps_link가 없고 좌표가 있는 경우 → 좌표 링크 자동 생성
       const generatedMapsUrl = !googleMapsLink && finalCoords
-        ? `https://www.google.com/maps/search/?api=1&query=${finalCoords.lat},${finalCoords.lng}`
+        ? buildMapsUrlByCoords(finalCoords.lat, finalCoords.lng)
         : null;
 
       // 실제 저장할 googleMapsUrl:

--- a/src/app/admin/import/_actions/import-actions.ts
+++ b/src/app/admin/import/_actions/import-actions.ts
@@ -3,7 +3,7 @@
 import Papa from "papaparse";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { expandGoogleMapsShortUrl, resolveGoogleMapsUrl } from "@/lib/google-maps-url";
+import { expandGoogleMapsShortUrl, resolveGoogleMapsUrl, buildStreetViewUrl } from "@/lib/google-maps-url";
 import { detectPlatform } from "@/lib/platform";
 import type { SourceType } from "@prisma/client";
 
@@ -462,10 +462,15 @@ export async function importSheetRows(rowIds: string[]): Promise<{
         ? { lat: placeInfo.lat, lng: placeInfo.lng }
         : coordFromMapsLink ?? coordFromStreetView ?? null;
 
-      // google_maps_link가 없고 street_view_url에서 좌표를 얻은 경우
-      // → /@lat,lng,17z 형태의 좌표 링크 자동 생성
+      // 순수 Street View URL만 공식 포맷으로 변환 (/place/ 포토뷰어 URL은 그대로 유지)
+      const officialStreetViewUrl =
+        finalStreetViewUrl && finalCoords && !finalStreetViewUrl.includes("/place/")
+          ? buildStreetViewUrl(finalCoords.lat, finalCoords.lng)
+          : finalStreetViewUrl;
+
+      // google_maps_link가 없고 좌표가 있는 경우 → 좌표 링크 자동 생성
       const generatedMapsUrl = !googleMapsLink && finalCoords
-        ? `https://www.google.com/maps/@${finalCoords.lat},${finalCoords.lng},17z`
+        ? `https://www.google.com/maps/search/?api=1&query=${finalCoords.lat},${finalCoords.lng}`
         : null;
 
       // 실제 저장할 googleMapsUrl:
@@ -559,7 +564,7 @@ export async function importSheetRows(rowIds: string[]): Promise<{
                 operatingHours: placeInfo.operatingHours ? (placeInfo.operatingHours as object) : undefined,
                 rating: placeInfo.rating ?? null,
                 gettingThere: (r["getting_there"] ?? "").trim() || null,
-                streetViewUrl: finalStreetViewUrl,
+                streetViewUrl: officialStreetViewUrl,
                 placeTypes,
                 status: placeStatus,
                 source: "ADMIN",
@@ -581,7 +586,7 @@ export async function importSheetRows(rowIds: string[]): Promise<{
               googlePlaceId: null,
               googleMapsUrl: googleMapsUrlToStore,
               gettingThere: (r["getting_there"] ?? "").trim() || null,
-              streetViewUrl: finalStreetViewUrl,
+              streetViewUrl: officialStreetViewUrl,
               placeTypes,
               status: placeStatus,
               source: "ADMIN",

--- a/src/app/admin/places/actions.ts
+++ b/src/app/admin/places/actions.ts
@@ -147,7 +147,7 @@ export async function resolveCoordinateLink(url: string): Promise<{
       return {
         lat: resolved.lat,
         lng: resolved.lng,
-        googleMapsUrl: `https://www.google.com/maps/@${resolved.lat},${resolved.lng},17z`,
+        googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${resolved.lat},${resolved.lng}`,
       };
     }
     if (resolved?.type === "streetview") {

--- a/src/app/admin/places/actions.ts
+++ b/src/app/admin/places/actions.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { Prisma } from "@prisma/client";
 import type { PlaceStatus } from "@prisma/client";
-import { resolveGoogleMapsUrl } from "@/lib/google-maps-url";
+import { resolveGoogleMapsUrl, toOfficialStreetViewUrl } from "@/lib/google-maps-url";
 import { makeStorageExtractor, deleteStorageFiles } from "@/lib/storage";
 
 const extractStoragePath = makeStorageExtractor("place-images");
@@ -63,6 +63,9 @@ export async function createPlace(
 ): Promise<{ error?: string; id?: string }> {
   let newId: string | undefined;
   try {
+    const streetViewUrl = data.streetViewUrl
+      ? await toOfficialStreetViewUrl(data.streetViewUrl)
+      : null;
     const place = await prisma.place.create({
       data: {
         nameKo: data.nameKo,
@@ -77,7 +80,7 @@ export async function createPlace(
         googleMapsUrl: data.googleMapsUrl || null,
         naverMapsUrl: data.naverMapsUrl || null,
         kakaoMapsUrl: data.kakaoMapsUrl || null,
-        streetViewUrl: data.streetViewUrl || null,
+        streetViewUrl,
         phone: data.phone || null,
         operatingHours: data.operatingHours?.length ? data.operatingHours : Prisma.DbNull,
         gettingThere: data.gettingThere || null,
@@ -100,6 +103,9 @@ export async function updatePlace(
   returnUrl?: string,
 ): Promise<{ error?: string }> {
   try {
+    const streetViewUrl = data.streetViewUrl
+      ? await toOfficialStreetViewUrl(data.streetViewUrl)
+      : null;
     await prisma.place.update({
       where: { id },
       data: {
@@ -115,7 +121,7 @@ export async function updatePlace(
         googleMapsUrl: data.googleMapsUrl || null,
         naverMapsUrl: data.naverMapsUrl || null,
         kakaoMapsUrl: data.kakaoMapsUrl || null,
-        streetViewUrl: data.streetViewUrl || null,
+        streetViewUrl,
         phone: data.phone || null,
         operatingHours: data.operatingHours?.length ? data.operatingHours : Prisma.DbNull,
         gettingThere: data.gettingThere || null,

--- a/src/app/admin/places/actions.ts
+++ b/src/app/admin/places/actions.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { Prisma } from "@prisma/client";
 import type { PlaceStatus } from "@prisma/client";
-import { resolveGoogleMapsUrl, toOfficialStreetViewUrl } from "@/lib/google-maps-url";
+import { resolveGoogleMapsUrl, toOfficialStreetViewUrl, buildMapsUrlByCoords } from "@/lib/google-maps-url";
 import { makeStorageExtractor, deleteStorageFiles } from "@/lib/storage";
 
 const extractStoragePath = makeStorageExtractor("place-images");
@@ -153,7 +153,7 @@ export async function resolveCoordinateLink(url: string): Promise<{
       return {
         lat: resolved.lat,
         lng: resolved.lng,
-        googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${resolved.lat},${resolved.lng}`,
+        googleMapsUrl: buildMapsUrlByCoords(resolved.lat, resolved.lng),
       };
     }
     if (resolved?.type === "streetview") {

--- a/src/components/maps/PlaceSearchDialog.tsx
+++ b/src/components/maps/PlaceSearchDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { resolveCoordinateLink } from "@/app/admin/places/actions";
+import { buildMapsUrlByPlaceId } from "@/lib/google-maps-url";
 
 const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
 const MAP_ID = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID ?? "DEMO_MAP_ID";
@@ -236,7 +237,7 @@ function PlaceSearchContent({
         addressEn,
         phone: selected.nationalPhoneNumber ?? "",
         operatingHours,
-        googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.displayName ?? "")}&query_place_id=${placeId}`,
+        googleMapsUrl: buildMapsUrlByPlaceId(selected.displayName ?? "", placeId),
         lat: selectedLat!,
         lng: selectedLng!,
         googlePlaceId: placeId,

--- a/src/components/maps/PlaceSearchDialog.tsx
+++ b/src/components/maps/PlaceSearchDialog.tsx
@@ -236,7 +236,7 @@ function PlaceSearchContent({
         addressEn,
         phone: selected.nationalPhoneNumber ?? "",
         operatingHours,
-        googleMapsUrl: `https://www.google.com/maps/place/?q=place_id:${placeId}`,
+        googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.displayName ?? "")}&query_place_id=${placeId}`,
         lat: selectedLat!,
         lng: selectedLng!,
         googlePlaceId: placeId,

--- a/src/lib/google-maps-url.ts
+++ b/src/lib/google-maps-url.ts
@@ -1,23 +1,6 @@
 // ─── 구글 맵 URL 유틸 ─────────────────────────────────────────────────────────
 // Admin PlaceForm과 Import 액션에서 공통으로 사용하는 구글 맵 URL 파싱 로직
 
-export function buildStreetViewUrl(lat: number, lng: number): string {
-  return `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${lat},${lng}`;
-}
-
-// 순수 Street View URL → 공식 Maps URL API 포맷으로 변환
-// /place/ 경로가 있는 포토뷰어 URL은 앱에서 정상 작동하므로 변환하지 않음
-export async function toOfficialStreetViewUrl(url: string): Promise<string> {
-  if (!url) return url;
-  if (url.includes("map_action=pano")) return url; // 이미 공식 포맷
-  if (url.includes("/place/")) return url;          // 포토뷰어 URL - 그대로 유지
-  const resolved = await resolveGoogleMapsUrl(url);
-  if (resolved?.type === "streetview" && resolved.lat && resolved.lng) {
-    return buildStreetViewUrl(resolved.lat, resolved.lng);
-  }
-  return url; // 파싱 실패 시 원본 유지
-}
-
 export async function expandGoogleMapsShortUrl(url: string): Promise<string> {
   if (!url || (!url.includes("maps.app.goo.gl") && !url.includes("goo.gl/maps"))) return url;
   try {
@@ -85,4 +68,32 @@ export async function resolveGoogleMapsUrl(url: string): Promise<ResolvedGoogleM
   } catch {
     return null;
   }
+}
+
+// place_id가 있는 장소 URL 생성
+export function buildMapsUrlByPlaceId(displayName: string, placeId: string): string {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(displayName)}&query_place_id=${placeId}`;
+}
+
+// 좌표 기반 Maps URL 생성
+export function buildMapsUrlByCoords(lat: number, lng: number): string {
+  return `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`;
+}
+
+// Street View URL 생성
+export function buildStreetViewUrl(lat: number, lng: number): string {
+  return `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${lat},${lng}`;
+}
+
+// 순수 Street View URL → 공식 Maps URL API 포맷으로 변환
+// /place/ 경로가 있는 포토뷰어 URL은 앱에서 정상 작동하므로 변환하지 않음
+export async function toOfficialStreetViewUrl(url: string): Promise<string> {
+  if (!url) return url;
+  if (url.includes("map_action=pano")) return url; // 이미 공식 포맷
+  if (url.includes("/place/")) return url;          // 포토뷰어 URL - 그대로 유지
+  const resolved = await resolveGoogleMapsUrl(url);
+  if (resolved?.type === "streetview" && resolved.lat && resolved.lng) {
+    return buildStreetViewUrl(resolved.lat, resolved.lng);
+  }
+  return url; // 파싱 실패 시 원본 유지
 }

--- a/src/lib/google-maps-url.ts
+++ b/src/lib/google-maps-url.ts
@@ -1,6 +1,23 @@
 // ─── 구글 맵 URL 유틸 ─────────────────────────────────────────────────────────
 // Admin PlaceForm과 Import 액션에서 공통으로 사용하는 구글 맵 URL 파싱 로직
 
+export function buildStreetViewUrl(lat: number, lng: number): string {
+  return `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${lat},${lng}`;
+}
+
+// 순수 Street View URL → 공식 Maps URL API 포맷으로 변환
+// /place/ 경로가 있는 포토뷰어 URL은 앱에서 정상 작동하므로 변환하지 않음
+export async function toOfficialStreetViewUrl(url: string): Promise<string> {
+  if (!url) return url;
+  if (url.includes("map_action=pano")) return url; // 이미 공식 포맷
+  if (url.includes("/place/")) return url;          // 포토뷰어 URL - 그대로 유지
+  const resolved = await resolveGoogleMapsUrl(url);
+  if (resolved?.type === "streetview" && resolved.lat && resolved.lng) {
+    return buildStreetViewUrl(resolved.lat, resolved.lng);
+  }
+  return url; // 파싱 실패 시 원본 유지
+}
+
 export async function expandGoogleMapsShortUrl(url: string): Promise<string> {
   if (!url || (!url.includes("maps.app.goo.gl") && !url.includes("goo.gl/maps"))) return url;
   try {


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->
구글맵 링크가 모바일에서 "No results found" 오류를 일으키던 비공식 URL 포맷을 Google 공식 Maps URL API   포맷으로 교체하고, 기존 DB에 저장된 26건도 일괄 마이그레이션.

추가로 Street View URL이 모바일에서 "Unsupported link"로 열리지 않는 문제도 함께 수정.
공식 `map_action=pano` 딥링크 포맷으로 변환하고 기존 DB 86건 마이그레이션.

## 변경 사항

- [ ] 구글맵 URL 생성 로직을 공식 포맷으로 변경 (PlaceSearchDialog.tsx, AddPlaceOverlay.tsx,  
admin/places/actions.ts)                                                                                    
  - [ ] 기존: https://www.google.com/maps/place/?q=place_id:ChIJxxx
  - [ ] 변경: https://www.google.com/maps/search/?api=1&query=장소명&query_place_id=ChIJxxx                     
- [ ] 기존 DB에 저장된 구버전 URL 26건 마이그레이션 (scripts/migrate-google-maps-url.ts)  
---
- [ ] Street View URL을 공식 딥링크 포맷으로 변환 유틸 추가 (src/lib/google-maps-url.ts)                        
  - 기존: https://maps.app.goo.gl/xxx                                                                       
  - 변경: https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=LAT,LNG
-  [ ] 저장/import 시 Street View URL 자동 변환 (admin/places/actions.ts, import-actions.ts)
- [ ] 기존 DB Street View URL 86건 마이그레이션 (scripts/migrate-street-view-url.ts)


## 스크린샷
<!-- UI 변경이 있으면 첨부. 없으면 삭제 -->
<img width="414" height="896" alt="IMG_8095" src="https://github.com/user-attachments/assets/8f4d3534-d1bd-4058-b362-45e0d704fef7" />
<img width="414" height="896" alt="IMG_8096" src="https://github.com/user-attachments/assets/d3b27b98-49e2-427a-9e24-f5ac4c7a472e" />
---
<img width="414" height="896" alt="IMG_8107" src="https://github.com/user-attachments/assets/ba61f84a-51ea-4ea6-b3e4-8e9378c3f340" />
<img width="414" height="896" alt="IMG_8106" src="https://github.com/user-attachments/assets/925260a8-a969-48fc-ac94-dbb64b861733" />




## 리뷰 포인트
<!-- 리뷰어가 특히 봐줬으면 하는 부분. 없으면 삭제 -->

