### PR TITLE
feature: dev/prod Supabase 환경 분리 + 운영자 GA 트래픽 제외

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,31 @@
-# Supabase (인증용으로 유지)
+# ─── Supabase ────────────────────────────────────────────────────────────────
+# Auth + DB 연결. dev/prod 프로젝트별로 다른 값 사용.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_SERVICE_ROLE_KEY=  # ⚠️ 서버사이드 전용. NEXT_PUBLIC_ 절대 금지 (클라이언트 노출 시 RLS 우회 가능)
 
-# Cloudflare R2 (이미지 스토리지)
+# DB 연결 URL (Prisma). dev/prod 프로젝트별로 다른 값 사용.
+DATABASE_URL=   # Supabase 연결 풀러 URL (port 6543) — PrismaClient 런타임용
+DIRECT_URL=     # Supabase 직접 연결 URL (port 5432) — prisma migrate 전용
+
+# ─── Cloudflare R2 (이미지 스토리지, dev/prod 공유) ──────────────────────────
 R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 NEXT_PUBLIC_CDN_URL=
 
-# Prisma / Database
-DATABASE_URL=
-DIRECT_URL=
-
-# Google Maps
+# ─── Google Maps ─────────────────────────────────────────────────────────────
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=
 
-# Gemini AI
+# ─── Google AI / Gemini ──────────────────────────────────────────────────────
 GEMINI_API_KEY=
 
-# Google Analytics 4
+# ─── Analytics ───────────────────────────────────────────────────────────────
+# Google Analytics 4 (dev에서는 비워두거나 테스트 ID 사용 권장)
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
 
-# Google Sheets Import
-GOOGLE_SHEETS_ID=             # 스프레드시트 ID (URL에서 추출)
-GOOGLE_SHEETS_GID=0           # 시트 탭 GID (기본값: 0)
+# ─── Google Sheets Import ─────────────────────────────────────────────────────
+GOOGLE_SHEETS_ID=
+GOOGLE_SHEETS_GID=0

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",
+    "build:vercel": "prisma migrate deploy && prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
     "seed:dummy": "npx tsx prisma/seed-dummy.ts"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -12,8 +12,10 @@ export default defineConfig({
     // Prisma v7: seed는 prisma.config.ts의 migrations.seed로 설정
     seed: "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts",
   },
-  // Migrate용 직접 연결 URL (Supabase의 connection pooler 우회)
   datasource: {
+    // ⚠️ Prisma CLI(migrate, introspect, db push) 전용 연결 설정.
+    // - 런타임 쿼리는 src/lib/prisma.ts의 pg 어댑터가 DATABASE_URL(pooler) 사용
+    // - 마이그레이션은 DIRECT_URL(port 5432) 사용 — pooler에서는 마이그레이션 불가
     url: process.env.DIRECT_URL ?? process.env.DATABASE_URL,
   },
 });

--- a/prisma/scripts/seed-from-prod.ts
+++ b/prisma/scripts/seed-from-prod.ts
@@ -1,0 +1,254 @@
+// .env.local 로드 — tsx/ts-node는 자동으로 읽지 않음
+try {
+  process.loadEnvFile(".env.local");
+} catch {}
+
+import { PrismaClient, Prisma } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import * as readline from "readline";
+
+// ─── 유틸 ─────────────────────────────────────────────────────────────────────
+
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+function parseDbInfo(url: string): { host: string; ref: string } {
+  try {
+    const u = new URL(url);
+    return { host: u.host, ref: u.username };
+  } catch {
+    return { host: "(parse error)", ref: "(parse error)" };
+  }
+}
+
+function createClient(connectionString: string): PrismaClient {
+  return new PrismaClient({ adapter: new PrismaPg({ connectionString }) });
+}
+
+// ─── 진행 추적 ────────────────────────────────────────────────────────────────
+
+const TOTAL = 18;
+let step = 0;
+let totalRows = 0;
+
+function log(table: string, count: number) {
+  step++;
+  totalRows += count;
+  console.log(`[${step}/${TOTAL}] ${table}: ${count} rows`);
+}
+
+// ─── wipe ─────────────────────────────────────────────────────────────────────
+
+async function wipeDevDb(devDb: PrismaClient) {
+  console.log("\n🗑  dev DB 초기화 중... (TRUNCATE CASCADE)");
+  // CASCADE로 ReCreeshot 등 의존 테이블도 자동 처리
+  await devDb.$executeRaw`
+    TRUNCATE TABLE
+      "GuideVideo", "Policy", "CuratedSection", "HomeBanner",
+      "PostTopic", "PostTag", "PostSource", "PostPlace", "PostImage", "Post",
+      "PlaceImage", "Place", "PlaceType", "Area",
+      "Tag", "TagGroupConfig", "Topic", "User"
+    CASCADE
+  `;
+  console.log("✅ 초기화 완료\n");
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const DEV_URL = process.env.DATABASE_URL;
+  const PROD_URL = process.env.PROD_DATABASE_URL;
+
+  if (!DEV_URL || !PROD_URL) {
+    console.error("❌ 필수 환경변수 누락:");
+    if (!DEV_URL) console.error("   DATABASE_URL (.env.local)");
+    if (!PROD_URL) console.error("   PROD_DATABASE_URL (런타임 주입 필요)");
+    console.error("\n실행 방법 (히스토리 회피용 leading space):");
+    console.error('    PROD_DATABASE_URL="postgresql://..." pnpm tsx prisma/scripts/seed-from-prod.ts');
+    process.exit(1);
+  }
+
+  const dev = parseDbInfo(DEV_URL);
+  const prod = parseDbInfo(PROD_URL);
+
+  console.log("\n📋 연결 정보 확인");
+  console.log(`  Prod  host: ${prod.host}  ref: ${prod.ref}`);
+  console.log(`  Dev   host: ${dev.host}   ref: ${dev.ref}`);
+
+  if (prod.ref === dev.ref) {
+    console.error("\n❌ prod ref와 dev ref가 동일합니다. 같은 DB를 가리키고 있습니다. 중단합니다.");
+    process.exit(1);
+  }
+
+  // SEED_YES=1 SEED_MODE=wipe|skip 로 비대화형 실행 가능
+  const nonInteractive = process.env.SEED_YES === "1" && !!process.env.SEED_MODE;
+
+  let mode: string;
+
+  if (nonInteractive) {
+    mode = process.env.SEED_MODE!.trim().toLowerCase();
+    console.log(`\n[비대화형] SEED_YES=1 SEED_MODE=${mode}`);
+  } else {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    const confirm = await ask(rl, "\nContinue? (yes/no): ");
+    if (confirm.trim() !== "yes") {
+      console.log("Aborted.");
+      rl.close();
+      process.exit(0);
+    }
+
+    console.log("\ndev DB 초기화 정책 선택:");
+    console.log("  wipe  — 해당 테이블 전체 삭제 후 import (TRUNCATE CASCADE, clean slate)");
+    console.log("  skip  — 중복 row는 건너뜀 (createMany skipDuplicates)");
+    console.log("  abort — 종료");
+
+    mode = (await ask(rl, "\n선택 (wipe/skip/abort): ")).trim().toLowerCase();
+    rl.close();
+  }
+
+  if (mode !== "wipe" && mode !== "skip") {
+    console.log("Aborted.");
+    process.exit(0);
+  }
+
+  const prodDb = createClient(PROD_URL);
+  const devDb = createClient(DEV_URL);
+
+  try {
+    if (mode === "wipe") await wipeDevDb(devDb);
+
+    const skipDuplicates = mode === "skip";
+    console.log("📥 데이터 import 시작\n");
+
+    // 1. User (ADMIN/EDITOR only) — 먼저 import해야 Post.authorId FK 충족
+    const users = await prodDb.user.findMany({
+      where: { role: { in: ["ADMIN", "EDITOR"] } },
+    });
+    await devDb.user.createMany({ data: users, skipDuplicates });
+    log("User (ADMIN/EDITOR)", users.length);
+    const adminIds = new Set(users.map((u) => u.id));
+
+    // 2. TagGroupConfig
+    const tagGroupConfigs = await prodDb.tagGroupConfig.findMany({});
+    await devDb.tagGroupConfig.createMany({ data: tagGroupConfigs, skipDuplicates });
+    log("TagGroupConfig", tagGroupConfigs.length);
+
+    // 3. Topic — level 오름차순 정렬 (parentId 자기참조: 부모 먼저)
+    const topics = await prodDb.topic.findMany({ orderBy: { level: "asc" } });
+    await devDb.topic.createMany({ data: topics, skipDuplicates });
+    log("Topic", topics.length);
+
+    // 4. Tag
+    const tags = await prodDb.tag.findMany({});
+    await devDb.tag.createMany({ data: tags, skipDuplicates });
+    log("Tag", tags.length);
+
+    // 5. Area — level 오름차순 정렬 (parentId 자기참조: 부모 먼저)
+    const areas = await prodDb.area.findMany({ orderBy: { level: "asc" } });
+    await devDb.area.createMany({ data: areas, skipDuplicates });
+    log("Area", areas.length);
+
+    // 6. PlaceType
+    const placeTypes = await prodDb.placeType.findMany({});
+    await devDb.placeType.createMany({ data: placeTypes, skipDuplicates });
+    log("PlaceType", placeTypes.length);
+
+    // 7. Place
+    const places = await prodDb.place.findMany({});
+    await devDb.place.createMany({
+      data: places.map((p) => ({ ...p, operatingHours: p.operatingHours ?? Prisma.DbNull })),
+      skipDuplicates,
+    });
+    log("Place", places.length);
+
+    // 8. PlaceImage
+    const placeImages = await prodDb.placeImage.findMany({});
+    await devDb.placeImage.createMany({ data: placeImages, skipDuplicates });
+    log("PlaceImage", placeImages.length);
+
+    // 9. Post — authorId가 dev에 없는 user를 가리키면 null 처리
+    const posts = await prodDb.post.findMany({});
+    const sanitizedPosts = posts.map((p) => ({
+      ...p,
+      authorId: p.authorId && adminIds.has(p.authorId) ? p.authorId : null,
+    }));
+    await devDb.post.createMany({ data: sanitizedPosts, skipDuplicates });
+    log("Post", posts.length);
+    const postIds = posts.map((p) => p.id);
+
+    // 10. PostImage
+    const postImages = await prodDb.postImage.findMany({
+      where: { postId: { in: postIds } },
+    });
+    await devDb.postImage.createMany({ data: postImages, skipDuplicates });
+    log("PostImage", postImages.length);
+
+    // 11. PostPlace
+    const postPlaces = await prodDb.postPlace.findMany({
+      where: { postId: { in: postIds } },
+    });
+    await devDb.postPlace.createMany({
+      data: postPlaces.map((p) => ({ ...p, insightEn: p.insightEn ?? Prisma.DbNull })),
+      skipDuplicates,
+    });
+    log("PostPlace", postPlaces.length);
+
+    // 12. PostSource
+    const postSources = await prodDb.postSource.findMany({
+      where: { postId: { in: postIds } },
+    });
+    await devDb.postSource.createMany({ data: postSources, skipDuplicates });
+    log("PostSource", postSources.length);
+
+    // 13. PostTag
+    const postTags = await prodDb.postTag.findMany({
+      where: { postId: { in: postIds } },
+    });
+    await devDb.postTag.createMany({ data: postTags, skipDuplicates });
+    log("PostTag", postTags.length);
+
+    // 14. PostTopic
+    const postTopics = await prodDb.postTopic.findMany({
+      where: { postId: { in: postIds } },
+    });
+    await devDb.postTopic.createMany({ data: postTopics, skipDuplicates });
+    log("PostTopic", postTopics.length);
+
+    // 15. HomeBanner
+    const homeBanners = await prodDb.homeBanner.findMany({
+      where: { postId: { in: postIds } },
+    });
+    await devDb.homeBanner.createMany({
+      data: homeBanners.map((b) => ({ ...b, labelOverrides: b.labelOverrides ?? Prisma.DbNull })),
+      skipDuplicates,
+    });
+    log("HomeBanner", homeBanners.length);
+
+    // 16. CuratedSection
+    const curatedSections = await prodDb.curatedSection.findMany({});
+    await devDb.curatedSection.createMany({ data: curatedSections, skipDuplicates });
+    log("CuratedSection", curatedSections.length);
+
+    // 17. Policy
+    const policies = await prodDb.policy.findMany({});
+    await devDb.policy.createMany({ data: policies, skipDuplicates });
+    log("Policy", policies.length);
+
+    // 18. GuideVideo
+    const guideVideos = await prodDb.guideVideo.findMany({});
+    await devDb.guideVideo.createMany({ data: guideVideos, skipDuplicates });
+    log("GuideVideo", guideVideos.length);
+
+    console.log(`\n✅ 완료: ${TOTAL}개 테이블, 총 ${totalRows} rows imported`);
+  } catch (e) {
+    console.error(`\n❌ 에러 발생 (step ${step + 1}/${TOTAL}):`, e);
+    process.exit(1);
+  } finally {
+    await prodDb.$disconnect();
+    await devDb.$disconnect();
+  }
+}
+
+main();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { Noto_Sans, Noto_Sans_KR } from "next/font/google";
-import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ToastProvider } from "@/components/toast-provider";
 import { GoogleAnalytics } from "@/components/GoogleAnalytics";
+import { VercelAnalytics } from "@/components/VercelAnalytics";
 import "./globals.css";
 
 const notoSans = Noto_Sans({
@@ -58,7 +58,7 @@ export default function RootLayout({
       <body className={`${notoSans.variable} ${notoSansKR.variable} font-sans antialiased`} suppressHydrationWarning>
         <GoogleAnalytics />
         <ToastProvider>{children}</ToastProvider>
-        <Analytics />
+        <VercelAnalytics />
         <SpeedInsights />
       </body>
     </html>

--- a/src/components/GAPageViewTracker.tsx
+++ b/src/components/GAPageViewTracker.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function GAPageViewTracker({ id }: { id: string }) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname.startsWith("/admin")) return;
+    if (typeof window === "undefined" || !window.gtag) return;
+    window.gtag("config", id, { page_path: pathname });
+  }, [pathname, id]);
+
+  return null;
+}

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,8 +1,13 @@
 import Script from "next/script";
+import { getCurrentUser } from "@/lib/auth";
+import { GAPageViewTracker } from "./GAPageViewTracker";
 
-export function GoogleAnalytics() {
+export async function GoogleAnalytics() {
   const id = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
   if (!id) return null;
+
+  const user = await getCurrentUser();
+  if (user?.role === "ADMIN" || user?.role === "EDITOR") return null;
 
   return (
     <>
@@ -15,9 +20,10 @@ export function GoogleAnalytics() {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '${id}', { send_page_view: true });
+          gtag('config', '${id}', { send_page_view: false });
         `}
       </Script>
+      <GAPageViewTracker id={id} />
     </>
   );
 }

--- a/src/components/VercelAnalytics.tsx
+++ b/src/components/VercelAnalytics.tsx
@@ -1,0 +1,8 @@
+import { getCurrentUser } from "@/lib/auth";
+import { VercelAnalyticsClient } from "./VercelAnalyticsClient";
+
+export async function VercelAnalytics() {
+  const user = await getCurrentUser();
+  if (user?.role === "ADMIN" || user?.role === "EDITOR") return null;
+  return <VercelAnalyticsClient />;
+}

--- a/src/components/VercelAnalyticsClient.tsx
+++ b/src/components/VercelAnalyticsClient.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Analytics } from "@vercel/analytics/react";
+
+export function VercelAnalyticsClient() {
+  return (
+    <Analytics
+      beforeSend={(event) => {
+        try {
+          const { pathname } = new URL(event.url);
+          if (pathname.startsWith("/admin")) return null;
+        } catch {
+          // URL 파싱 실패 시 안전하게 통과
+        }
+        return event;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->

### 1. dev/prod Supabase 환경 분리

- dev 전용 Supabase 프로젝트(recree-dev) 생성 후 분리
- 환경변수 구조 정비: 로컬/Preview는 dev DB, Production은 prod DB
- `.env.example` 카테고리별 헤더 + 변수 주석 추가
- `package.json`: `build` / `build:vercel` 스크립트 분리
- `prisma.config.ts`: directUrl 사용 명시 주석 보강
- `prisma/scripts/seed-from-prod.ts`: prod → dev 콘텐츠 복사 스크립트(재사용 가능)

### 2. 운영자 트래픽 GA 분석 제외

- `GoogleAnalytics`를 async Server Component로 변환
- role이 ADMIN/EDITOR이면 GA 스크립트 자체를 렌더링하지 않음
- `send_page_view: false` + `GAPageViewTracker`로 page_view 수동 전송
- `/admin` 경로에서는 page_view 미전송

### 3. Vercel Analytics에서 운영자 트래픽 및 /admin 경로 제외
- VercelAnalytics를 async Server Component로 래핑
- role이 ADMIN/EDITOR이면 Analytics 자체 미렌더링
- VercelAnalyticsClient에서 beforeSend로 /admin 경로 비콘 차단
- @vercel/speed-insights는 그대로 유지 (성능 지표는 운영자 환경도 측정 의미 있음)

## 검증

- [x] 로컬: dev DB 연결 + OAuth 로그인 정상
- [x] recree.io (prod): prod DB 연결 + 정상 동작
- [x] dev.recree.io: dev DB 연결 + 정상 빌드/배포
- [x] ADMIN 계정 로그인 시 GA 미로드 확인 (Network 0건, window.gtag undefined)
- [x] 비로그인/USER 계정 시 GA 정상 로드 확인
- [x] dev DB에 prod 콘텐츠 1,971 rows 복사 완료 (User만 ADMIN 4명)

## 환경변수 셋업 상태 (Vercel)

- Production 스코프: prod Supabase 키 5개
- Preview 스코프: dev Supabase 키 5개
- 그 외(R2/Maps/Gemini/Sheets/GA): 양쪽 동일 (공유)


## 참고

후속 이슈로 분리됨:
- chore: schema.prisma와 마이그레이션 히스토리 동기화
- chore: Vercel 빌드 시 prisma migrate deploy 자동화 활성화 (선행 의존)
- chore: 외부 핫링크 R2 마이그레이션
- chore: R2 dev/prod 버킷 분리 검토
- feat: 운영자 트래픽 GA 제외 — 본 PR로 처리됨

부수 작업:
- prod DB 비밀번호 회전 (보안 사고 대응)
- dev DB 비밀번호 회전
- prod Supabase Storage 정리 (763MB → 0)
