### PR TITLE
fix: 관리자 포스트 수정/등록 화면에서 수동 지정한 slug가 영문 제목으로 덮어써지는 문제 & 포스트관리 정렬기능

### DIFF
--- a/src/app/admin/posts/_actions/post-actions.ts
+++ b/src/app/admin/posts/_actions/post-actions.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import type { PostStatus, SourceType } from "@prisma/client";
+import { Prisma, type PostStatus, type SourceType } from "@prisma/client";
 import type { SourcePlatform } from "@/types";
 import { makeStorageExtractor, deleteStorageFiles } from "@/lib/storage";
 
@@ -242,12 +242,26 @@ function buildPostRelations(data: PostFormData) {
   };
 }
 
+// ─── slug 검증 ──────────────────────────────────────────────────────────────────
+
+// 정규식은 PostForm.tsx 클라이언트 검증과 동일하게 유지할 것
+const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function validateSlug(slug: string): string | null {
+  if (!slug.trim()) return "슬러그를 입력해주세요.";
+  if (!SLUG_REGEX.test(slug.trim())) return "슬러그는 소문자, 숫자, 하이픈(-)만 사용할 수 있습니다.";
+  return null;
+}
+
 // ─── 포스트 생성 ────────────────────────────────────────────────────────────────
 
 export async function createPost(
   data: PostFormData,
   returnUrl?: string,
 ): Promise<{ error?: string; id?: string }> {
+  const slugError = validateSlug(data.slug);
+  if (slugError) return { error: slugError };
+
   let newId: string | undefined;
   try {
     const user = await getCurrentUser();
@@ -256,7 +270,7 @@ export async function createPost(
       data: {
         titleKo: data.titleKo,
         titleEn: data.titleEn,
-        slug: data.slug,
+        slug: data.slug.trim(),
         bodyKo: data.bodyKo || null,
         bodyEn: data.bodyEn || null,
         status: data.status,
@@ -274,6 +288,9 @@ export async function createPost(
     revalidatePath("/discover");
   } catch (e) {
     console.error(e);
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return { error: "이미 사용 중인 슬러그입니다. 다른 슬러그를 입력해주세요." };
+    }
     return { error: "포스트를 생성하는 중 오류가 발생했습니다." };
   }
   if (returnUrl) redirect(returnUrl);
@@ -287,6 +304,9 @@ export async function updatePost(
   data: PostFormData,
   returnUrl?: string,
 ): Promise<{ error?: string }> {
+  const slugError = validateSlug(data.slug);
+  if (slugError) return { error: slugError };
+
   try {
     // Storage 정리를 위해 기존 데이터 먼저 조회
     const existing = await prisma.post.findUnique({
@@ -309,7 +329,7 @@ export async function updatePost(
         data: {
           titleKo: data.titleKo,
           titleEn: data.titleEn,
-          slug: data.slug,
+          slug: data.slug.trim(),
           bodyKo: data.bodyKo || null,
           bodyEn: data.bodyEn || null,
           status: data.status,
@@ -353,6 +373,9 @@ export async function updatePost(
     revalidatePath("/discover");
   } catch (e) {
     console.error(e);
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return { error: "이미 사용 중인 슬러그입니다. 다른 슬러그를 입력해주세요." };
+    }
     return { error: "포스트를 수정하는 중 오류가 발생했습니다." };
   }
   if (returnUrl) redirect(returnUrl);

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -500,6 +500,7 @@ export function PostForm({
     if (!titleEn.trim()) { toast.error("영어 제목을 입력해주세요."); return; }
     if (!slug.trim()) { toast.error("슬러그를 입력해주세요."); return; }
     if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug.trim())) { toast.error("슬러그 형식을 확인해주세요."); return; }
+    if (slugStatus === "checking") { toast.error("슬러그 확인 중입니다. 잠시 후 다시 시도해주세요."); return; }
     if (slugStatus === "error") { toast.error("슬러그가 이미 사용 중입니다."); return; }
 
     if (finalStatus === "PUBLISHED") {
@@ -616,7 +617,7 @@ export function PostForm({
 
             <Button
               size="sm"
-              disabled={isPending || slugStatus === "error" || slugStatus === "invalid"}
+              disabled={isPending || slugStatus === "checking" || slugStatus === "error" || slugStatus === "invalid"}
               onClick={() => {
                 if (status === "PUBLISHED") handleSubmit("PUBLISHED");
                 else handleSubmit("DRAFT");
@@ -630,7 +631,7 @@ export function PostForm({
               <Button
                 size="sm"
                 className="bg-brand text-black hover:bg-brand/90"
-                disabled={isPending || slugStatus === "error" || slugStatus === "invalid"}
+                disabled={isPending || slugStatus === "checking" || slugStatus === "error" || slugStatus === "invalid"}
                 onClick={() => handleSubmit("PUBLISHED")}
               >
                 발행

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -205,17 +205,6 @@ const EMPTY_SOURCE: PostSourceInput = {
   isOriginalLink: false,
 };
 
-// ─── 유틸 ──────────────────────────────────────────────────────────────────────
-
-function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-");
-}
-
 // ─── PostForm 컴포넌트 ──────────────────────────────────────────────────────────
 
 export function PostForm({
@@ -297,7 +286,6 @@ export function PostForm({
 
   // ── UI 상태 ─────────────────────────────────────────────────────────────────
   const [slugStatus, setSlugStatus] = useState<"idle" | "checking" | "ok" | "error">("idle");
-  const [slugManual, setSlugManual] = useState(false);
   const [placePickerOpen, setPlacePickerOpen] = useState(false);
   const [isTranslating, setIsTranslating] = useState(false);
   const [isTranslatingTitle, setIsTranslatingTitle] = useState(false);
@@ -325,13 +313,7 @@ export function PostForm({
     [tagGroups],
   );
 
-  // ── Slug 자동 생성 + 중복 체크 ─────────────────────────────────────────────
-  useEffect(() => {
-    if (slugManual) return;
-    if (!titleEn.trim()) return;
-    setSlug(generateSlug(titleEn));
-  }, [titleEn, slugManual]);
-
+  // ── Slug 중복 체크 ────────────────────────────────────────────────────────
   const slugCheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (!slug.trim()) {
@@ -727,7 +709,7 @@ export function PostForm({
                       <div className="flex items-center gap-1.5">
                         <input
                           value={slug}
-                          onChange={(e) => { setSlugManual(true); setSlug(e.target.value); }}
+                          onChange={(e) => { setSlug(e.target.value); }}
                           placeholder="url-friendly-slug"
                           className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${
                             slugStatus === "error" ? "border-destructive" : slugStatus === "ok" ? "border-green-500" : ""
@@ -737,11 +719,6 @@ export function PostForm({
                         {slugStatus === "ok" && <Check className="h-4 w-4 text-green-600 shrink-0" />}
                         {slugStatus === "error" && <span className="text-xs text-destructive shrink-0">중복</span>}
                       </div>
-                      {slugManual && (
-                        <button type="button" className="text-xs text-muted-foreground underline" onClick={() => { setSlugManual(false); setSlug(generateSlug(titleEn)); }}>
-                          자동 생성으로 되돌리기
-                        </button>
-                      )}
                     </div>
 
                   </CardContent>

--- a/src/app/admin/posts/_components/PostForm.tsx
+++ b/src/app/admin/posts/_components/PostForm.tsx
@@ -285,7 +285,7 @@ export function PostForm({
   const [activePlaceIndex, setActivePlaceIndex] = useState(0);
 
   // ── UI 상태 ─────────────────────────────────────────────────────────────────
-  const [slugStatus, setSlugStatus] = useState<"idle" | "checking" | "ok" | "error">("idle");
+  const [slugStatus, setSlugStatus] = useState<"idle" | "checking" | "ok" | "error" | "invalid">("idle");
   const [placePickerOpen, setPlacePickerOpen] = useState(false);
   const [isTranslating, setIsTranslating] = useState(false);
   const [isTranslatingTitle, setIsTranslatingTitle] = useState(false);
@@ -318,6 +318,10 @@ export function PostForm({
   useEffect(() => {
     if (!slug.trim()) {
       setSlugStatus("idle");
+      return;
+    }
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug.trim())) {
+      setSlugStatus("invalid");
       return;
     }
     setSlugStatus("checking");
@@ -495,6 +499,7 @@ export function PostForm({
     if (!titleKo.trim()) { toast.error("한국어 제목을 입력해주세요."); return; }
     if (!titleEn.trim()) { toast.error("영어 제목을 입력해주세요."); return; }
     if (!slug.trim()) { toast.error("슬러그를 입력해주세요."); return; }
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug.trim())) { toast.error("슬러그 형식을 확인해주세요."); return; }
     if (slugStatus === "error") { toast.error("슬러그가 이미 사용 중입니다."); return; }
 
     if (finalStatus === "PUBLISHED") {
@@ -611,7 +616,7 @@ export function PostForm({
 
             <Button
               size="sm"
-              disabled={isPending || slugStatus === "error"}
+              disabled={isPending || slugStatus === "error" || slugStatus === "invalid"}
               onClick={() => {
                 if (status === "PUBLISHED") handleSubmit("PUBLISHED");
                 else handleSubmit("DRAFT");
@@ -625,7 +630,7 @@ export function PostForm({
               <Button
                 size="sm"
                 className="bg-brand text-black hover:bg-brand/90"
-                disabled={isPending || slugStatus === "error"}
+                disabled={isPending || slugStatus === "error" || slugStatus === "invalid"}
                 onClick={() => handleSubmit("PUBLISHED")}
               >
                 발행
@@ -704,21 +709,32 @@ export function PostForm({
                     {/* 슬러그 */}
                     <div className="space-y-1.5">
                       <div className="flex items-center h-6">
-                        <span className="text-xs font-medium text-muted-foreground">슬러그</span>
+                        <span className="text-xs font-medium text-muted-foreground">슬러그 <span className="text-red-500">*</span></span>
                       </div>
                       <div className="flex items-center gap-1.5">
                         <input
                           value={slug}
-                          onChange={(e) => { setSlug(e.target.value); }}
+                          onChange={(e) => {
+                            const normalized = e.target.value
+                              .toLowerCase()
+                              .replace(/\s+/g, "-");
+                            setSlug(normalized);
+                          }}
                           placeholder="url-friendly-slug"
                           className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${
-                            slugStatus === "error" ? "border-destructive" : slugStatus === "ok" ? "border-green-500" : ""
+                            slugStatus === "error" || slugStatus === "invalid" ? "border-destructive" : slugStatus === "ok" ? "border-green-500" : ""
                           }`}
                         />
                         {slugStatus === "checking" && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />}
                         {slugStatus === "ok" && <Check className="h-4 w-4 text-green-600 shrink-0" />}
-                        {slugStatus === "error" && <span className="text-xs text-destructive shrink-0">중복</span>}
+                        {(slugStatus === "error" || slugStatus === "invalid") && <X className="h-4 w-4 text-destructive shrink-0" />}
                       </div>
+                      {slugStatus === "invalid" && (
+                        <p className="text-xs text-destructive">소문자, 숫자, 하이픈(-)만 사용할 수 있어요.</p>
+                      )}
+                      {slugStatus === "error" && (
+                        <p className="text-xs text-destructive">이미 사용 중인 슬러그입니다.</p>
+                      )}
                     </div>
 
                   </CardContent>

--- a/src/app/admin/posts/_components/PostsFilters.tsx
+++ b/src/app/admin/posts/_components/PostsFilters.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 interface Props {
   currentSearch: string;
   currentStatus: string;
+  currentSort: string;
 }
 
 const PostsFiltersInner = dynamic(

--- a/src/app/admin/posts/_components/PostsFiltersInner.tsx
+++ b/src/app/admin/posts/_components/PostsFiltersInner.tsx
@@ -15,20 +15,22 @@ import {
 interface Props {
   currentSearch: string;
   currentStatus: string;
+  currentSort: string;
 }
 
 function buildUrl(
   pathname: string,
-  values: { search: string; status: string },
+  values: { search: string; status: string; sort: string },
 ): string {
   const sp = new URLSearchParams();
   if (values.search) sp.set("search", values.search);
   if (values.status) sp.set("status", values.status);
+  if (values.sort && values.sort !== "latest") sp.set("sort", values.sort);
   const qs = sp.toString();
   return qs ? `${pathname}?${qs}` : pathname;
 }
 
-export function PostsFiltersInner({ currentSearch, currentStatus }: Props) {
+export function PostsFiltersInner({ currentSearch, currentStatus, currentSort }: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const [searchValue, setSearchValue] = useState(currentSearch);
@@ -41,7 +43,7 @@ export function PostsFiltersInner({ currentSearch, currentStatus }: Props) {
     }
     const t = setTimeout(() => {
       router.push(
-        buildUrl(pathname, { search: searchValue, status: currentStatus }),
+        buildUrl(pathname, { search: searchValue, status: currentStatus, sort: currentSort }),
       );
     }, 300);
     return () => clearTimeout(t);
@@ -50,7 +52,11 @@ export function PostsFiltersInner({ currentSearch, currentStatus }: Props) {
 
   const handleStatusChange = (value: string) => {
     const status = value === "all" ? "" : value;
-    router.push(buildUrl(pathname, { search: searchValue, status }));
+    router.push(buildUrl(pathname, { search: searchValue, status, sort: currentSort }));
+  };
+
+  const handleSortChange = (sort: string) => {
+    router.push(buildUrl(pathname, { search: searchValue, status: currentStatus, sort }));
   };
 
   return (
@@ -76,6 +82,20 @@ export function PostsFiltersInner({ currentSearch, currentStatus }: Props) {
           <SelectItem value="all">전체 상태</SelectItem>
           <SelectItem value="DRAFT">임시저장</SelectItem>
           <SelectItem value="PUBLISHED">발행됨</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={currentSort || "latest"}
+        onValueChange={handleSortChange}
+      >
+        <SelectTrigger className="w-36 rounded-lg bg-white shadow-sm border-0">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="latest">생성일순</SelectItem>
+          <SelectItem value="updated">수정일순</SelectItem>
+          <SelectItem value="views">조회수순</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/src/app/admin/posts/_components/PostsTable.tsx
+++ b/src/app/admin/posts/_components/PostsTable.tsx
@@ -30,6 +30,7 @@ export type PostRow = {
   titleEn: string;
   slug: string;
   status: PostStatus;
+  viewCount: number;
   publishedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
@@ -140,6 +141,9 @@ export function PostsTable({ posts, isFiltered, currentPage = 1 }: Props) {
                 <th className="text-left px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">
                   수정일
                 </th>
+                <th className="text-right px-4 py-3 font-medium text-muted-foreground whitespace-nowrap">
+                  조회수
+                </th>
                 <th className="w-24 px-2 py-3" />
               </tr>
             </thead>
@@ -147,7 +151,7 @@ export function PostsTable({ posts, isFiltered, currentPage = 1 }: Props) {
               {posts.length === 0 && (
                 <tr>
                   <td
-                    colSpan={7}
+                    colSpan={8}
                     className="px-4 py-16 text-center text-sm text-muted-foreground"
                   >
                     {isFiltered
@@ -249,6 +253,11 @@ export function PostsTable({ posts, isFiltered, currentPage = 1 }: Props) {
                   {/* 수정일 */}
                   <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
                     {formatDate(post.updatedAt)}
+                  </td>
+
+                  {/* 조회수 */}
+                  <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap text-right">
+                    {post.viewCount.toLocaleString()}
                   </td>
 
                   {/* 액션 */}

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -158,7 +158,7 @@ export default async function PostsPage({
   const filterParams = new URLSearchParams();
   if (search) filterParams.set("search", search);
   if (status) filterParams.set("status", status);
-  if (sort && sort in SORT_MAP) filterParams.set("sort", sort);
+  if (sortKey !== "latest") filterParams.set("sort", sortKey);
   const filterQuery = filterParams.toString();
 
   return (

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -9,6 +9,12 @@ import { PlacesPagination } from "../places/_components/PlacesPagination";
 
 const PAGE_SIZE = 20;
 
+const SORT_MAP: Record<string, Prisma.PostOrderByWithRelationInput> = {
+  latest: { createdAt: "desc" },
+  updated: { updatedAt: "desc" },
+  views: { viewCount: "desc" },
+};
+
 export default async function PostsPage({
   searchParams,
 }: {
@@ -16,12 +22,15 @@ export default async function PostsPage({
     page?: string;
     search?: string;
     status?: string;
+    sort?: string;
   }>;
 }) {
   const params = await searchParams;
   const page = Math.max(1, Number(params.page) || 1);
   const search = params.search?.trim() ?? "";
   const status = params.status ?? "";
+  const sort = params.sort ?? "";
+  const sortKey = sort && sort in SORT_MAP ? sort : "latest";
 
   const where: Prisma.PostWhereInput = {
     ...(search && {
@@ -42,6 +51,7 @@ export default async function PostsPage({
         titleEn: true,
         slug: true,
         status: true,
+        viewCount: true,
         publishedAt: true,
         createdAt: true,
         updatedAt: true,
@@ -97,7 +107,7 @@ export default async function PostsPage({
           },
         },
       },
-      orderBy: { createdAt: "desc" },
+      orderBy: SORT_MAP[sortKey],
       skip: (page - 1) * PAGE_SIZE,
       take: PAGE_SIZE,
     }),
@@ -148,6 +158,7 @@ export default async function PostsPage({
   const filterParams = new URLSearchParams();
   if (search) filterParams.set("search", search);
   if (status) filterParams.set("status", status);
+  if (sort && sort in SORT_MAP) filterParams.set("sort", sort);
   const filterQuery = filterParams.toString();
 
   return (
@@ -167,7 +178,7 @@ export default async function PostsPage({
         </Button>
       </div>
 
-      <PostsFilters currentSearch={search} currentStatus={status} />
+      <PostsFilters currentSearch={search} currentStatus={status} currentSort={sortKey} />
 
       <PostsTable posts={postsWithResolvedColors} isFiltered={isFiltered} currentPage={page} />
       <PlacesPagination


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->
관리자 포스트 관리 기능 개선. 두 가지 작업을 포함한다.
1. slug 입력 모델을 "자동생성"에서 "수동 입력 필수"로 전환 (+ 검증 강화)
2. 포스트 목록 테이블에 정렬 기능과 조회수 컬럼 추가

### 배경
- slug가 영문 제목 기반으로 자동 생성되면서, 수동 수정한 slug가 화면 재진입 시
  자동생성값으로 덮어써지는 버그가 있었다. 이로 인해 관리자가 130개 중 약 60개를
  반복 수정하는 비효율이 발생했다. (DB에는 정상 저장되었으나 화면 표시가 원복됨)
- 색인 품질을 위해 slug를 일관성 있게 관리하는 작업의 일환으로, slug를 관리자가
  의도적으로 설계하는 값으로 전환했다.
- 포스트 수가 늘어 목록 정렬/조회수 확인 니즈가 생겼다.

## 변경 사항
### 1. slug 수동 입력 전환
- slug 자동생성 로직 제거 (generateSlug, slugManual, 자동생성 useEffect)
- slug 필수 입력화 (label 필수 표시, placeholder 형식 가이드)
- 입력 자동 정규화: 공백 → 하이픈, 대문자 → 소문자
- 실시간 검증 상태 분리: 형식오류(invalid)와 중복(error)을 구분해 각각 안내
  - 입력칸 아래 헬퍼 텍스트로 상태별 가이드 표시
  - 형식오류/중복/확인중 상태에서 저장·발행 버튼 비활성화
- 서버 사이드 검증 추가 (post-actions.ts): 클라이언트 우회 대비 빈값/형식 재검증,
  P2002(중복) 에러를 사용자 친화 메시지로 변환

### 2. 포스트 목록 정렬 + 조회수
- 정렬 드롭다운 추가: 생성일순(기본) / 수정일순 / 조회수순
  - URL searchParam(`?sort=`) 기반 서버 정렬 (Prisma orderBy)
  - 화이트리스트(SORT_MAP)로 잘못된 파라미터는 기본값으로 fallback
  - 기본값(생성일순)은 URL에 파라미터를 붙이지 않아 깨끗한 URL 유지
  - 검색·상태·정렬 파라미터 상호 유지
- 조회수 컬럼 추가 (천 단위 구분 표시)

## 영향 범위
- 관리자 전용 페이지에 한정. 일반 사용자 영향 없음
- **DB/스키마 변경 없음** (viewCount, publishedAt 등 기존 필드만 사용)
- 마이그레이션 불필요

## 스크린샷
<!-- UI 변경이 있으면 첨부. 없으면 삭제 -->


## 리뷰 포인트
<!-- 리뷰어가 특히 봐줬으면 하는 부분. 없으면 삭제 -->

