### PR TITLE
feature: Home 화면 피드형으로 전환

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "NODE_OPTIONS='--experimental-require-module' prisma generate && next build",
     "build:vercel": "prisma migrate deploy && prisma generate && next build",
     "start": "next start",
     "lint": "eslint",

--- a/prisma/migrations/20260522000000_add_show_on_home_to_curated_section/migration.sql
+++ b/prisma/migrations/20260522000000_add_show_on_home_to_curated_section/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "CuratedSection" ADD COLUMN "showOnHome" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260522000001_fix_show_on_home_default_false/migration.sql
+++ b/prisma/migrations/20260522000001_fix_show_on_home_default_false/migration.sql
@@ -1,0 +1,5 @@
+-- 1. 컬럼 default를 false로 변경
+ALTER TABLE "CuratedSection" ALTER COLUMN "showOnHome" SET DEFAULT false;
+
+-- 2. 기존 데이터(모두 true로 들어간 것)를 false로 리셋
+UPDATE "CuratedSection" SET "showOnHome" = false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -461,6 +461,7 @@ model CuratedSection {
   maxCount      Int         @default(10)
   order         Int         @default(0)
   isActive      Boolean     @default(true)
+  showOnHome    Boolean     @default(false)
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
 

--- a/src/app/(user)/_actions/feed-actions.ts
+++ b/src/app/(user)/_actions/feed-actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { getPostsWithLabels, type PostItem } from "@/lib/post-queries";
+
+const DEFAULT_TAKE = 10;
+
+export async function fetchLatestFeed({
+  cursor,
+  take = DEFAULT_TAKE,
+}: {
+  cursor?: string;
+  take?: number;
+} = {}): Promise<{ posts: PostItem[]; nextCursor: string | null }> {
+  const posts = await getPostsWithLabels(
+    { status: "PUBLISHED" },
+    {
+      take,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      cursor,
+    }
+  );
+  const nextCursor = posts.length === take ? posts[posts.length - 1].id : null;
+  return { posts, nextCursor };
+}

--- a/src/app/(user)/_actions/feed-actions.ts
+++ b/src/app/(user)/_actions/feed-actions.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { getPostsWithLabels, type PostItem } from "@/lib/post-queries";
+import { getCurrentUser } from "@/lib/auth";
+import { getMyFollows } from "@/lib/follow-queries";
 
 const DEFAULT_TAKE = 10;
 
@@ -20,5 +22,33 @@ export async function fetchLatestFeed({
     }
   );
   const nextCursor = posts.length === take ? posts[posts.length - 1].id : null;
+  return { posts, nextCursor };
+}
+
+export async function fetchFollowFeed({
+  cursor,
+}: {
+  cursor?: string;
+} = {}): Promise<{ posts: PostItem[]; nextCursor: string | null }> {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) return { posts: [], nextCursor: null };
+
+  const follows = await getMyFollows(currentUser.id);
+  const topicIds = follows.map((f) => f.topic.id);
+  if (topicIds.length === 0) return { posts: [], nextCursor: null };
+
+  const posts = await getPostsWithLabels(
+    {
+      status: "PUBLISHED",
+      postTopics: { some: { topicId: { in: topicIds } } },
+    },
+    {
+      take: 10,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      cursor,
+    }
+  );
+
+  const nextCursor = posts.length === 10 ? posts[posts.length - 1].id : null;
   return { posts, nextCursor };
 }

--- a/src/app/(user)/_components/FeedCard.tsx
+++ b/src/app/(user)/_components/FeedCard.tsx
@@ -52,15 +52,15 @@ export function FeedCard({
         </div>
 
         {/* 제목 */}
-        <h3 className="text-base font-semibold leading-relaxed line-clamp-2 text-foreground">
+        <h3 className="text-base font-semibold leading-snug line-clamp-2 text-foreground">
           {post.titleEn}
         </h3>
 
         {/* 장소명 */}
         {placeName && (
-          <div className="flex items-center gap-0.5 text-[11px] text-muted-foreground">
+          <div className="flex items-center gap-0.5 text-xs text-muted-foreground">
             <MapPin className="h-2.5 w-2.5 shrink-0" />
-            <span className="line-clamp-1">{placeName}</span>
+            <span className="line-clamp-1 font-medium">{placeName}</span>
           </div>
         )}
       </div>

--- a/src/app/(user)/_components/FeedCard.tsx
+++ b/src/app/(user)/_components/FeedCard.tsx
@@ -20,44 +20,49 @@ export function FeedCard({
     post.postPlaces[0]?.place.nameEn ?? post.postPlaces[0]?.place.nameKo;
 
   return (
-    <Link href={`/posts/${post.slug}`}>
-      <div className="relative aspect-video rounded-lg overflow-hidden bg-muted">
-        {post.postImages[0]?.url ? (
-          <Image
-            src={post.postImages[0].url}
-            alt={post.titleEn}
-            fill
-            unoptimized={isExternalImage(post.postImages[0].url)}
-            className="object-cover"
-            style={focalStyle(
-              post.postImages[0].focalX,
-              post.postImages[0].focalY,
-              post.postImages[0].zoom,
-            )}
-            sizes="(max-width: 672px) 100vw, 672px"
-          />
-        ) : (
-          <div className="w-full h-full bg-muted" />
-        )}
-      </div>
-      <div className="mt-2.5 flex flex-col gap-1">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex-1 min-w-0 flex flex-col gap-1">
-            <PostBadges post={post} tagGroupMap={tagGroupMap} variant="list" />
-            {placeName && (
-              <div className="flex items-center gap-0.5 text-xs text-muted-foreground">
-                <MapPin className="h-3 w-3 shrink-0" />
-                <span className="line-clamp-1">{placeName}</span>
-              </div>
-            )}
-          </div>
-          <div className="shrink-0">
-            <ScrapButton postId={post.id} initialSaved={isSaved ?? false} size="md" />
-          </div>
+    <Link href={`/posts/${post.slug}`} className="block">
+      <div className="flex flex-col gap-2">
+        {/* 사진 */}
+        <div className="relative aspect-video rounded-lg overflow-hidden bg-muted">
+          {post.postImages[0]?.url ? (
+            <Image
+              src={post.postImages[0].url}
+              alt={post.titleEn}
+              fill
+              unoptimized={isExternalImage(post.postImages[0].url)}
+              className="object-cover"
+              style={focalStyle(
+                post.postImages[0].focalX,
+                post.postImages[0].focalY,
+                post.postImages[0].zoom,
+              )}
+              sizes="(max-width: 672px) 100vw, 672px"
+            />
+          ) : (
+            <div className="w-full h-full bg-muted" />
+          )}
         </div>
-        <h3 className="text-base font-semibold leading-snug line-clamp-2 text-foreground">
+
+        {/* 칩 + 북마크 */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <PostBadges post={post} tagGroupMap={tagGroupMap} variant="list" />
+          </div>
+          <ScrapButton postId={post.id} initialSaved={isSaved ?? false} size="md" />
+        </div>
+
+        {/* 제목 */}
+        <h3 className="text-base font-semibold leading-relaxed line-clamp-2 text-foreground">
           {post.titleEn}
         </h3>
+
+        {/* 장소명 */}
+        {placeName && (
+          <div className="flex items-center gap-0.5 text-[11px] text-muted-foreground">
+            <MapPin className="h-2.5 w-2.5 shrink-0" />
+            <span className="line-clamp-1">{placeName}</span>
+          </div>
+        )}
       </div>
     </Link>
   );

--- a/src/app/(user)/_components/FeedCard.tsx
+++ b/src/app/(user)/_components/FeedCard.tsx
@@ -46,7 +46,7 @@ export function FeedCard({
         {/* 칩 + 북마크 */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex-1 min-w-0">
-            <PostBadges post={post} tagGroupMap={tagGroupMap} variant="list" />
+            <PostBadges post={post} tagGroupMap={tagGroupMap} variant="list" pillFontSize="0.75rem" />
           </div>
           <ScrapButton postId={post.id} initialSaved={isSaved ?? false} size="md" />
         </div>

--- a/src/app/(user)/_components/FeedCard.tsx
+++ b/src/app/(user)/_components/FeedCard.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import Image from "next/image";
+import { MapPin } from "lucide-react";
+import { focalStyle, isExternalImage } from "@/lib/image";
+import { type TagGroupColorMap } from "@/lib/post-labels";
+import type { PostItem } from "@/lib/post-queries";
+import { PostBadges } from "./PostCard";
+import { ScrapButton } from "./ScrapButton";
+
+export function FeedCard({
+  post,
+  tagGroupMap,
+  isSaved,
+}: {
+  post: PostItem;
+  tagGroupMap: TagGroupColorMap;
+  isSaved?: boolean;
+}) {
+  const placeName =
+    post.postPlaces[0]?.place.nameEn ?? post.postPlaces[0]?.place.nameKo;
+
+  return (
+    <Link href={`/posts/${post.slug}`}>
+      <div className="relative aspect-video rounded-lg overflow-hidden bg-muted">
+        {post.postImages[0]?.url ? (
+          <Image
+            src={post.postImages[0].url}
+            alt={post.titleEn}
+            fill
+            unoptimized={isExternalImage(post.postImages[0].url)}
+            className="object-cover"
+            style={focalStyle(
+              post.postImages[0].focalX,
+              post.postImages[0].focalY,
+              post.postImages[0].zoom,
+            )}
+            sizes="(max-width: 672px) 100vw, 672px"
+          />
+        ) : (
+          <div className="w-full h-full bg-muted" />
+        )}
+      </div>
+      <div className="mt-2.5 flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex-1 min-w-0 flex flex-col gap-1">
+            <PostBadges post={post} tagGroupMap={tagGroupMap} variant="list" />
+            {placeName && (
+              <div className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                <MapPin className="h-3 w-3 shrink-0" />
+                <span className="line-clamp-1">{placeName}</span>
+              </div>
+            )}
+          </div>
+          <div className="shrink-0">
+            <ScrapButton postId={post.id} initialSaved={isSaved ?? false} size="md" />
+          </div>
+        </div>
+        <h3 className="text-base font-semibold leading-snug line-clamp-2 text-foreground">
+          {post.titleEn}
+        </h3>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(user)/_components/HomeBannerCarousel.tsx
+++ b/src/app/(user)/_components/HomeBannerCarousel.tsx
@@ -1,13 +1,13 @@
-"use client";
-
-import { useState, useEffect, useCallback, useRef } from "react";
 import Image from "next/image";
-import { isExternalImage, focalStyle } from "@/lib/image";
 import Link from "next/link";
+import { MapPin } from "lucide-react";
+import { isExternalImage, focalStyle } from "@/lib/image";
 import { labelBackground } from "@/lib/post-labels";
 import { LabelBadge } from "@/components/LabelBadge";
+import { ScrapButton } from "./ScrapButton";
 
 export type BannerItem = {
+  id: string;
   slug: string;
   titleEn: string;
   displayName: string;
@@ -23,93 +23,77 @@ export type BannerItem = {
     gradientStop: number;
     textColorHex: string;
   }[];
+  isSaved: boolean;
 };
 
 export function HomeBannerCarousel({ banners }: { banners: BannerItem[] }) {
-  const [current, setCurrent] = useState(0);
-  const touchStartX = useRef<number | null>(null);
-
-  const next = useCallback(() => {
-    setCurrent((prev) => (prev + 1) % banners.length);
-  }, [banners.length]);
-
-  const prev = useCallback(() => {
-    setCurrent((prev) => (prev - 1 + banners.length) % banners.length);
-  }, [banners.length]);
-
-  useEffect(() => {
-    if (banners.length <= 1) return;
-    const timer = setInterval(next, 4000);
-    return () => clearInterval(timer);
-  }, [next, banners.length]);
-
   if (banners.length === 0) return null;
 
-  const banner = banners[current];
-
   return (
-    <div
-      className="relative w-full aspect-[3/2] rounded-xl overflow-hidden"
-      onTouchStart={(e) => {
-        touchStartX.current = e.touches[0].clientX;
-      }}
-      onTouchEnd={(e) => {
-        if (touchStartX.current === null) return;
-        const dx = e.changedTouches[0].clientX - touchStartX.current;
-        if (dx < -40) next();
-        else if (dx > 40) prev();
-        touchStartX.current = null;
-      }}
-    >
-      <Link href={`/posts/${banner.slug}`} className="absolute inset-0">
-        {banner.thumbnailUrl ? (
-          <Image
-            src={banner.thumbnailUrl}
-            alt={banner.titleEn}
-            fill
-            unoptimized={isExternalImage(banner.thumbnailUrl)}
-            className="object-cover"
-            style={focalStyle(banner.focalX, banner.focalY, banner.zoom)}
-            sizes="(max-width: 672px) 100vw, 672px"
-            priority
-          />
-        ) : (
-          <div className="w-full h-full bg-muted" />
-        )}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
-        <div className="absolute bottom-6 left-4 right-4">
-          {banner.labels.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mb-1 [--pill-fs:var(--text-xs)]">
-              {banner.labels.map((label, i) => (
-                <LabelBadge
-                  key={i}
-                  text={label.text}
-                  background={labelBackground(label)}
-                  color={label.textColorHex}
+    <div className="overflow-x-auto scrollbar-hide">
+      <div className="flex items-start gap-3 pl-4 pb-2">
+        {banners.map((banner, index) => (
+          <Link
+            key={banner.slug}
+            href={`/posts/${banner.slug}`}
+            className={`shrink-0 w-[85%] rounded-xl overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.06)] bg-white${index === banners.length - 1 ? " mr-4" : ""}`}
+          >
+            {/* 사진 영역 */}
+            <div className="relative aspect-video overflow-hidden bg-muted">
+              {banner.thumbnailUrl ? (
+                <Image
+                  src={banner.thumbnailUrl}
+                  alt={banner.titleEn}
+                  fill
+                  unoptimized={isExternalImage(banner.thumbnailUrl)}
+                  className="object-cover"
+                  style={focalStyle(banner.focalX, banner.focalY, banner.zoom)}
+                  sizes="(max-width: 672px) 88vw, 565px"
+                  priority
                 />
-              ))}
+              ) : (
+                <div className="w-full h-full bg-muted" />
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+              <div className="absolute bottom-2 left-3 right-3 flex items-center gap-2">
+                <div className="flex-1 flex flex-wrap gap-1 [--pill-fs:var(--text-xs)]">
+                  {banner.labels.map((label, i) => (
+                    <LabelBadge
+                      key={i}
+                      text={label.text}
+                      background={labelBackground(label)}
+                      color={label.textColorHex}
+                    />
+                  ))}
+                </div>
+                <div className="shrink-0">
+                  <ScrapButton
+                    postId={banner.id}
+                    initialSaved={banner.isSaved}
+                    size="md"
+                    unsavedClassName="text-white/80 hover:text-white"
+                  />
+                </div>
+              </div>
             </div>
-          )}
-          <h2 className="text-white font-bold text-lg leading-tight">
-            {banner.displayName}
-          </h2>
-        </div>
-      </Link>
 
-      {/* 인디케이터 — 하단 중앙 */}
-      {banners.length > 1 && (
-        <div className="absolute bottom-3 left-0 right-0 flex justify-center gap-1.5 pointer-events-none">
-          {banners.map((_, i) => (
-            <button
-              key={i}
-              onClick={() => setCurrent(i)}
-              className={`h-1.5 rounded-full transition-all pointer-events-auto ${
-                i === current ? "w-5 bg-white" : "w-1.5 bg-white/50"
-              }`}
-            />
-          ))}
-        </div>
-      )}
+            {/* 텍스트 영역 */}
+            <div className="px-3 pt-2 pb-2">
+              <p className="text-base font-semibold leading-relaxed line-clamp-2 min-h-[3.25em] text-foreground">
+                {banner.titleEn}
+              </p>
+              <div className="flex items-center gap-0.5 text-[11px] text-muted-foreground mt-1 min-h-[1rem]">
+                {banner.displayName !== banner.titleEn && (
+                  <>
+                    <MapPin className="h-2.5 w-2.5 shrink-0" />
+                    <span className="line-clamp-1">{banner.displayName}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(user)/_components/HomeBannerCarousel.tsx
+++ b/src/app/(user)/_components/HomeBannerCarousel.tsx
@@ -79,7 +79,8 @@ export function HomeBannerCarousel({ banners }: { banners: BannerItem[] }) {
 
             {/* 텍스트 영역 */}
             <div className="px-3 pt-2 pb-2">
-              <p className="text-base font-semibold leading-relaxed line-clamp-2 min-h-[3.25em] text-foreground">
+              {/* min-h: leading-snug 2줄 높이(2×1.375em=2.75em)에 맞춘 값. leading 변경 시 함께 조정 필요 */}
+              <p className="text-base font-semibold leading-snug line-clamp-2 min-h-[2.75em] text-foreground">
                 {banner.titleEn}
               </p>
               <div className="flex items-center gap-0.5 text-[11px] text-muted-foreground mt-1 min-h-[1rem]">

--- a/src/app/(user)/_components/HomeBannerCarousel.tsx
+++ b/src/app/(user)/_components/HomeBannerCarousel.tsx
@@ -48,7 +48,7 @@ export function HomeBannerCarousel({ banners }: { banners: BannerItem[] }) {
                   unoptimized={isExternalImage(banner.thumbnailUrl)}
                   className="object-cover"
                   style={focalStyle(banner.focalX, banner.focalY, banner.zoom)}
-                  sizes="(max-width: 672px) 88vw, 565px"
+                  sizes="(max-width: 672px) 85vw, 560px"
                   priority
                 />
               ) : (

--- a/src/app/(user)/_components/HomeBannerCarousel.tsx
+++ b/src/app/(user)/_components/HomeBannerCarousel.tsx
@@ -36,7 +36,7 @@ export function HomeBannerCarousel({ banners }: { banners: BannerItem[] }) {
           <Link
             key={banner.slug}
             href={`/posts/${banner.slug}`}
-            className={`shrink-0 w-[85%] rounded-xl overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.06)] bg-white${index === banners.length - 1 ? " mr-4" : ""}`}
+            className={`shrink-0 w-[85%] rounded-xl overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.06)] bg-background${index === banners.length - 1 ? " mr-4" : ""}`}
           >
             {/* 사진 영역 */}
             <div className="relative aspect-video overflow-hidden bg-muted">

--- a/src/app/(user)/_components/InfiniteFeed.tsx
+++ b/src/app/(user)/_components/InfiniteFeed.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { fetchLatestFeed } from "../_actions/feed-actions";
+import { FeedCard } from "./FeedCard";
+import type { PostItem } from "@/lib/post-queries";
+import { type TagGroupColorMap } from "@/lib/post-labels";
+
+interface Props {
+  initialPosts: PostItem[];
+  initialCursor: string | null;
+  savedIds: string[];
+  tagGroupMap: TagGroupColorMap;
+}
+
+export function InfiniteFeed({
+  initialPosts,
+  initialCursor,
+  savedIds,
+  tagGroupMap,
+}: Props) {
+  const [posts, setPosts] = useState<PostItem[]>(initialPosts);
+  const [cursor, setCursor] = useState<string | null>(initialCursor);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isEnd, setIsEnd] = useState(initialCursor === null);
+  const [error, setError] = useState(false);
+
+  // Observer 콜백용 ref 미러 — stale closure 없이 최신 값을 읽기 위함
+  const loadingRef = useRef(false);
+  const cursorRef = useRef<string | null>(initialCursor);
+  const isEndRef = useRef(initialCursor === null);
+  const errorRef = useRef(false);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const savedSet = useMemo(() => new Set(savedIds), [savedIds]);
+
+  // ref만 읽으므로 의존성 없이 안정적. useCallback([])으로 감싸 Observer 등록 시 단 한 번만 사용.
+  const loadMore = useCallback(async () => {
+    if (loadingRef.current || isEndRef.current || errorRef.current || cursorRef.current === null) return;
+
+    loadingRef.current = true;
+    setIsLoading(true);
+    try {
+      const result = await fetchLatestFeed({ cursor: cursorRef.current });
+      setPosts((prev) => [...prev, ...result.posts]);
+      cursorRef.current = result.nextCursor;
+      setCursor(result.nextCursor);
+      if (result.nextCursor === null) {
+        isEndRef.current = true;
+        setIsEnd(true);
+      }
+    } catch {
+      errorRef.current = true;
+      setError(true);
+    } finally {
+      loadingRef.current = false;
+      setIsLoading(false);
+    }
+  }, []);
+
+  // loadMore는 useCallback([])으로 안정적 → 이 effect는 마운트 시 단 한 번만 실행
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div>
+      <div className="flex flex-col gap-10">
+        {posts.map((post) => (
+          <FeedCard
+            key={post.id}
+            post={post}
+            tagGroupMap={tagGroupMap}
+            isSaved={savedSet.has(post.id)}
+          />
+        ))}
+      </div>
+
+      {isLoading && (
+        <div className="flex flex-col gap-10 mt-6">
+          {[0, 1].map((i) => (
+            <div key={i} className="animate-pulse">
+              <div className="aspect-[4/3] rounded-lg bg-muted" />
+              <div className="mt-2.5 flex flex-col gap-2">
+                <div className="h-4 w-20 rounded bg-muted" />
+                <div className="h-3 w-32 rounded bg-muted" />
+                <div className="h-5 w-full rounded bg-muted" />
+                <div className="h-5 w-3/4 rounded bg-muted" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          Something went wrong.{" "}
+          <button
+            className="underline"
+            onClick={() => {
+              errorRef.current = false;
+              setError(false);
+              loadMore();
+            }}
+          >
+            Try again
+          </button>
+        </p>
+      )}
+
+      <div ref={sentinelRef} className="h-1" />
+    </div>
+  );
+}

--- a/src/app/(user)/_components/InfiniteFeed.tsx
+++ b/src/app/(user)/_components/InfiniteFeed.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
-import { fetchLatestFeed } from "../_actions/feed-actions";
 import { FeedCard } from "./FeedCard";
 import type { PostItem } from "@/lib/post-queries";
 import { type TagGroupColorMap } from "@/lib/post-labels";
+
+type FetchFn = (args: { cursor?: string }) => Promise<{ posts: PostItem[]; nextCursor: string | null }>;
 
 interface Props {
   initialPosts: PostItem[];
   initialCursor: string | null;
   savedIds: string[];
   tagGroupMap: TagGroupColorMap;
+  fetchFn: FetchFn;
 }
 
 export function InfiniteFeed({
@@ -18,6 +20,7 @@ export function InfiniteFeed({
   initialCursor,
   savedIds,
   tagGroupMap,
+  fetchFn,
 }: Props) {
   const [posts, setPosts] = useState<PostItem[]>(initialPosts);
   const [isLoading, setIsLoading] = useState(false);
@@ -41,7 +44,7 @@ export function InfiniteFeed({
     loadingRef.current = true;
     setIsLoading(true);
     try {
-      const result = await fetchLatestFeed({ cursor: cursorRef.current });
+      const result = await fetchFn({ cursor: cursorRef.current ?? undefined });
       setPosts((prev) => [...prev, ...result.posts]);
       cursorRef.current = result.nextCursor;
       if (result.nextCursor === null) {
@@ -55,9 +58,10 @@ export function InfiniteFeed({
       loadingRef.current = false;
       setIsLoading(false);
     }
-  }, []);
+  }, [fetchFn]);
 
-  // loadMore는 useCallback([])으로 안정적 → 이 effect는 마운트 시 단 한 번만 실행
+  // loadMore는 fetchFn이 안정적인 참조(server action)일 때 단 한 번만 등록됨
+
   useEffect(() => {
     const el = sentinelRef.current;
     if (!el) return;

--- a/src/app/(user)/_components/InfiniteFeed.tsx
+++ b/src/app/(user)/_components/InfiniteFeed.tsx
@@ -110,6 +110,7 @@ export function InfiniteFeed({
         <p className="mt-8 text-center text-sm text-muted-foreground">
           Something went wrong.{" "}
           <button
+            type="button"
             className="underline"
             onClick={() => {
               errorRef.current = false;

--- a/src/app/(user)/_components/InfiniteFeed.tsx
+++ b/src/app/(user)/_components/InfiniteFeed.tsx
@@ -20,7 +20,6 @@ export function InfiniteFeed({
   tagGroupMap,
 }: Props) {
   const [posts, setPosts] = useState<PostItem[]>(initialPosts);
-  const [cursor, setCursor] = useState<string | null>(initialCursor);
   const [isLoading, setIsLoading] = useState(false);
   const [isEnd, setIsEnd] = useState(initialCursor === null);
   const [error, setError] = useState(false);
@@ -45,7 +44,6 @@ export function InfiniteFeed({
       const result = await fetchLatestFeed({ cursor: cursorRef.current });
       setPosts((prev) => [...prev, ...result.posts]);
       cursorRef.current = result.nextCursor;
-      setCursor(result.nextCursor);
       if (result.nextCursor === null) {
         isEndRef.current = true;
         setIsEnd(true);
@@ -92,7 +90,7 @@ export function InfiniteFeed({
         <div className="flex flex-col gap-10 mt-6">
           {[0, 1].map((i) => (
             <div key={i} className="animate-pulse">
-              <div className="aspect-[4/3] rounded-lg bg-muted" />
+              <div className="aspect-video rounded-lg bg-muted" />
               <div className="mt-2.5 flex flex-col gap-2">
                 <div className="h-4 w-20 rounded bg-muted" />
                 <div className="h-3 w-32 rounded bg-muted" />
@@ -117,6 +115,12 @@ export function InfiniteFeed({
           >
             Try again
           </button>
+        </p>
+      )}
+
+      {isEnd && !isLoading && !error && posts.length > 0 && (
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          You're all caught up.
         </p>
       )}
 

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -52,16 +52,21 @@ export function PostBadges({
   post,
   tagGroupMap,
   variant = "home",
+  pillFontSize = "0.625rem",
 }: {
   post: PostItem;
   tagGroupMap: TagGroupColorMap;
   variant?: "home" | "list";
+  pillFontSize?: string;
 }) {
   const labels = resolvePostLabels(post, tagGroupMap, variant);
   if (labels.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-1 [--pill-fs:0.625rem]">
+    <div
+      className="flex flex-wrap gap-1"
+      style={{ "--pill-fs": pillFontSize } as React.CSSProperties}
+    >
       {labels.map((label, i) => (
         <LabelBadge
           key={i}

--- a/src/app/(user)/_components/PostCard.tsx
+++ b/src/app/(user)/_components/PostCard.tsx
@@ -115,7 +115,7 @@ export function PostCard({
             {post.postPlaces[0]?.place.nameEn ?? post.postPlaces[0]?.place.nameKo ?? post.titleEn}
           </p>
           <div className="shrink-0 z-10">
-            <ScrapButton postId={post.id} initialSaved={isSaved ?? false} size="sm" />
+            <ScrapButton postId={post.id} initialSaved={isSaved ?? false} size="sm" unsavedClassName="text-white/80 hover:text-white" />
           </div>
         </div>
       </div>

--- a/src/app/(user)/_components/ScrapButton.tsx
+++ b/src/app/(user)/_components/ScrapButton.tsx
@@ -9,15 +9,16 @@ interface Props {
   postId: string;
   initialSaved: boolean;
   size?: "sm" | "md";
+  unsavedClassName?: string;
 }
 
-export function ScrapButton({ postId, initialSaved, size = "md" }: Props) {
+export function ScrapButton({ postId, initialSaved, size = "md", unsavedClassName }: Props) {
   const [saved, setSaved] = useState(initialSaved);
   const [isPending, startTransition] = useTransition();
   const { toast, showToast } = useToast();
 
   const iconSize = size === "sm" ? "h-4 w-4" : "h-5 w-5";
-  const unsavedClass = "text-muted-foreground hover:text-foreground";
+  const unsavedClass = unsavedClassName ?? "text-muted-foreground hover:text-foreground";
 
   function handleClick(e: React.MouseEvent) {
     e.preventDefault();

--- a/src/app/(user)/_components/ScrollToTopButton.tsx
+++ b/src/app/(user)/_components/ScrollToTopButton.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+export function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const check = () => {
+      setVisible(window.scrollY > 600);
+      ticking = false;
+    };
+
+    const handleScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(check);
+        ticking = true;
+      }
+    };
+
+    // 마운트 시 초기 scrollY 즉시 체크
+    setVisible(window.scrollY > 600);
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label="맨 위로"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className={`
+        fixed bottom-[72px] right-2 z-50
+        size-10 rounded-full
+        flex items-center justify-center
+        backdrop-blur-sm
+        shadow-[0_4px_16px_rgba(0,0,0,0.18)]
+        transition-all duration-200
+        focus-visible:outline-none focus-visible:ring-2
+        focus-visible:ring-[#C8FF09] focus-visible:ring-offset-1
+        ${visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-2 pointer-events-none"
+        }
+      `}
+      style={{
+        /* brand(#C8FF09) → brand-sub(#D0FF6C) 반투명 라임 그라데이션 */
+        background: "linear-gradient(135deg, rgba(208,255,108,0.85), rgba(200,255,9,0.85))",
+        /* 0.5px 테두리 — Tailwind border는 1px 고정이라 style로 지정 */
+        border: "0.5px solid rgba(255,255,255,0.5)",
+      }}
+    >
+      <ArrowUp size={20} color="#2f3a00" strokeWidth={2.0} />
+    </button>
+  );
+}

--- a/src/app/(user)/_components/ScrollToTopButton.tsx
+++ b/src/app/(user)/_components/ScrollToTopButton.tsx
@@ -8,6 +8,7 @@ export function ScrollToTopButton() {
 
   useEffect(() => {
     let ticking = false;
+    let rafId = 0;
 
     const check = () => {
       setVisible(window.scrollY > 600);
@@ -16,7 +17,7 @@ export function ScrollToTopButton() {
 
     const handleScroll = () => {
       if (!ticking) {
-        requestAnimationFrame(check);
+        rafId = requestAnimationFrame(check);
         ticking = true;
       }
     };
@@ -25,7 +26,10 @@ export function ScrollToTopButton() {
     setVisible(window.scrollY > 600);
 
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      cancelAnimationFrame(rafId);
+    };
   }, []);
 
   return (
@@ -38,6 +42,7 @@ export function ScrollToTopButton() {
         size-10 rounded-full
         flex items-center justify-center
         backdrop-blur-sm
+        bg-white/80
         shadow-[0_4px_16px_rgba(0,0,0,0.18)]
         transition-all duration-200
         focus-visible:outline-none focus-visible:ring-2
@@ -48,8 +53,6 @@ export function ScrollToTopButton() {
         }
       `}
       style={{
-        /* brand(#C8FF09) → brand-sub(#D0FF6C) 반투명 라임 그라데이션 */
-        background: "linear-gradient(135deg, rgba(208,255,108,0.85), rgba(200,255,9,0.85))",
         /* 0.5px 테두리 — Tailwind border는 1px 고정이라 style로 지정 */
         border: "0.5px solid rgba(255,255,255,0.5)",
       }}

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -4,6 +4,7 @@ import { SavedHeader } from "./_components/SavedHeader";
 import { ConditionalHeader } from "./_components/ConditionalHeader";
 import { ConditionalBottomNav } from "./_components/ConditionalBottomNav";
 import { ActivityTracker } from "./_components/ActivityTracker";
+import { ScrollToTopButton } from "./_components/ScrollToTopButton";
 import { getCurrentUser } from "@/lib/auth";
 
 export default async function UserLayout({
@@ -24,6 +25,7 @@ export default async function UserLayout({
           profileImageUrl={user?.profileImageUrl ?? null}
         />
       </div>
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -38,8 +38,7 @@ import { SearchBar } from "./_components/SearchBar";
 import { GuideVideoCard } from "./_components/GuideVideoCard";
 import { getCurrentUser } from "@/lib/auth";
 import { ReCreeshotImage } from "@/components/recreeshot-image";
-import { getMyFollows } from "@/lib/follow-queries";
-import { fetchLatestFeed } from "./_actions/feed-actions";
+import { fetchLatestFeed, fetchFollowFeed } from "./_actions/feed-actions";
 import { InfiniteFeed } from "./_components/InfiniteFeed";
 
 // ─── 가로 스크롤 섹션 ────────────────────────────────────────────────────────
@@ -260,21 +259,13 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
   const hasBanners = homeBanners.length > 0;
   const hasSections = sectionData.some((d) => d.items.length > 0);
 
-  // Follow 탭 데이터 (tab=follow이고 로그인 상태일 때만)
-  let followPosts: PostItem[] = [];
-  let followedIds: string[] = [];
-  if (activeTab === "follow" && currentUser) {
-    const follows = await getMyFollows(currentUser.id);
-    followedIds = follows.map((f) => f.topic.id);
-    if (followedIds.length > 0) {
-      followPosts = await getPostsWithLabels(
-        {
-          status: "PUBLISHED",
-          postTopics: { some: { topicId: { in: followedIds } } },
-        },
-        { take: 20, orderBy: { createdAt: "desc" } }
-      );
-    }
+  // Follow 탭 첫 페이지 SSR (인증·팔로우 필터는 fetchFollowFeed 내부에서 처리)
+  let followFirstPosts: PostItem[] = [];
+  let followInitialCursor: string | null = null;
+  if (activeTab === "follow") {
+    const followResult = await fetchFollowFeed({});
+    followFirstPosts = followResult.posts;
+    followInitialCursor = followResult.nextCursor;
   }
 
   // ─── 폴백 ───────────────────────────────────────────────────────────────────
@@ -353,13 +344,13 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
               Sign in
             </Link>
           </div>
-        ) : followedIds.length === 0 ? (
+        ) : followFirstPosts.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-[50vh] gap-4 text-center px-4">
             <Heart className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} />
             <div className="space-y-1">
-              <p className="text-lg font-semibold">No topics followed yet</p>
+              <p className="text-lg font-semibold">No posts yet</p>
               <p className="text-sm text-muted-foreground">
-                Follow topics to curate your own feed.
+                Follow topics to see posts here.
               </p>
             </div>
             <Link
@@ -369,18 +360,15 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
               Browse Topics
             </Link>
           </div>
-        ) : followPosts.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-[50vh] gap-2 text-center px-4">
-            <p className="text-lg font-semibold">No posts yet</p>
-            <p className="text-sm text-muted-foreground">
-              Check back soon for posts from your followed topics.
-            </p>
-          </div>
         ) : (
-          <div className="px-4 grid grid-cols-2 gap-3">
-            {followPosts.map((post) => (
-              <PostCard key={post.id} post={post} tagGroupMap={tagGroupMap} isSaved={savedPostIds.has(post.id)} variant="grid" />
-            ))}
+          <div className="px-4">
+            <InfiniteFeed
+              fetchFn={fetchFollowFeed}
+              initialPosts={followFirstPosts}
+              initialCursor={followInitialCursor}
+              savedIds={[...savedPostIds]}
+              tagGroupMap={tagGroupMap}
+            />
           </div>
         )
       ) : (
@@ -453,6 +441,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
               initialCursor={latestFeedResult.nextCursor}
               savedIds={[...savedPostIds]}
               tagGroupMap={tagGroupMap}
+              fetchFn={fetchLatestFeed}
             />
           </div>
 

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -98,7 +98,7 @@ function TabBar({ activeTab }: { activeTab: "highlights" | "follow" }) {
             : "border-transparent text-muted-foreground hover:text-foreground"
         }`}
       >
-        Follow
+        Following
       </Link>
     </div>
   );

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -39,6 +39,8 @@ import { GuideVideoCard } from "./_components/GuideVideoCard";
 import { getCurrentUser } from "@/lib/auth";
 import { ReCreeshotImage } from "@/components/recreeshot-image";
 import { getMyFollows } from "@/lib/follow-queries";
+import { fetchLatestFeed } from "./_actions/feed-actions";
+import { InfiniteFeed } from "./_components/InfiniteFeed";
 
 // ─── 가로 스크롤 섹션 ────────────────────────────────────────────────────────
 
@@ -113,7 +115,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
 
   const guideVideo = await prisma.guideVideo.findFirst({ where: { isActive: true } });
 
-  const [homeBanners, sections, tagGroupConfigs, savedPostIds] = await Promise.all([
+  const [homeBanners, sections, tagGroupConfigs, savedPostIds, latestFeedResult] = await Promise.all([
     prisma.homeBanner.findMany({
       where: { isActive: true },
       orderBy: { order: "asc" },
@@ -185,6 +187,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
       select: { group: true, displayLabel: true, colorHex: true, colorHex2: true, gradientDir: true, gradientStop: true, textColorHex: true },
     }),
     getSavedPostIds(currentUser?.id ?? null),
+    fetchLatestFeed({}),
   ]);
 
   type SectionData =
@@ -438,6 +441,18 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
               </HScrollSection>
             );
           })}
+          <div className="flex items-center justify-between mb-3 px-4 mt-2">
+            <h2 className="font-bold text-lg">Latest</h2>
+          </div>
+          <div className="px-4">
+            <InfiniteFeed
+              initialPosts={latestFeedResult.posts}
+              initialCursor={latestFeedResult.nextCursor}
+              savedIds={[...savedPostIds]}
+              tagGroupMap={tagGroupMap}
+            />
+          </div>
+
           <footer className="px-4 pt-8 pb-6 text-sm text-muted-foreground">
             <div className="flex flex-wrap gap-4 justify-center">
               <Link href="/policy/privacy" className="hover:text-foreground underline underline-offset-4">

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -69,7 +69,7 @@ function HScrollSection({
       <div className="overflow-x-auto scrollbar-hide">
         <div className="flex gap-3 pl-4 pb-1">
           {children}
-          <div className="shrink-0 w-4" />
+          <div className="shrink-0 w-1" />
         </div>
       </div>
     </section>
@@ -123,6 +123,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
         id: true,
         post: {
           select: {
+            id: true,
             slug: true,
             titleEn: true,
             postImages: {
@@ -180,7 +181,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
       },
     }),
     prisma.curatedSection.findMany({
-      where: { isActive: true },
+      where: { isActive: true, showOnHome: true },
       orderBy: { order: "asc" },
     }),
     prisma.tagGroupConfig.findMany({
@@ -310,6 +311,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
   const bannerItems: BannerItem[] = homeBanners.map((b) => {
     const labels = resolveBannerLabels(b.post.postTopics, b.post.postTags, tagGroupMap);
     return {
+      id: b.post.id,
       slug: b.post.slug,
       titleEn: b.post.titleEn,
       displayName:
@@ -321,6 +323,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
       focalY: b.post.postImages[0]?.focalY ?? null,
       zoom: b.post.postImages[0]?.zoom ?? null,
       labels,
+      isSaved: savedPostIds.has(b.post.id),
     };
   });
 
@@ -383,7 +386,7 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
       ) : (
         <>
           {hasBanners && (
-            <div className="px-4 mb-4">
+            <div className="mb-4">
               <HomeBannerCarousel banners={bannerItems} />
             </div>
           )}

--- a/src/app/admin/home-curation/_actions/home-curation-actions.ts
+++ b/src/app/admin/home-curation/_actions/home-curation-actions.ts
@@ -117,3 +117,8 @@ export async function toggleSectionActive(id: string, isActive: boolean) {
   await prisma.curatedSection.update({ where: { id }, data: { isActive } });
   revalidate();
 }
+
+export async function toggleHomeSection(id: string, showOnHome: boolean) {
+  await prisma.curatedSection.update({ where: { id }, data: { showOnHome } });
+  revalidate();
+}

--- a/src/app/admin/home-curation/_components/SectionTab.tsx
+++ b/src/app/admin/home-curation/_components/SectionTab.tsx
@@ -23,6 +23,7 @@ import {
   deleteSection,
   reorderSections,
   toggleSectionActive,
+  toggleHomeSection,
 } from "../_actions/home-curation-actions";
 import { SectionDialog } from "./SectionDialog";
 import type { PickablePost } from "./PostPickerDialog";
@@ -44,6 +45,7 @@ export type SectionRow = {
   maxCount: number;
   order: number;
   isActive: boolean;
+  showOnHome: boolean;
 };
 
 function SortableSectionRow({
@@ -54,6 +56,7 @@ function SortableSectionRow({
   onEdit,
   onRemove,
   onToggle,
+  onSetHome,
 }: {
   section: SectionRow;
   topics: TopicOption[];
@@ -62,6 +65,7 @@ function SortableSectionRow({
   onEdit: (s: SectionRow) => void;
   onRemove: (id: string) => void;
   onToggle: (id: string, v: boolean) => void;
+  onSetHome: (id: string, v: boolean) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: section.id });
@@ -119,6 +123,12 @@ function SortableSectionRow({
         </div>
         <p className="text-xs text-muted-foreground mt-0.5 truncate">{getDescription()}</p>
       </div>
+
+      <Switch
+        checked={section.showOnHome}
+        onCheckedChange={(v) => onSetHome(section.id, v)}
+        className="shrink-0 data-[state=checked]:bg-brand"
+      />
 
       <Switch
         checked={section.isActive}
@@ -192,6 +202,13 @@ export function SectionTab({
     startTransition(() => toggleSectionActive(id, isActive));
   }
 
+  function handleSetHome(id: string, showOnHome: boolean) {
+    setSections((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, showOnHome } : s))
+    );
+    startTransition(() => toggleHomeSection(id, showOnHome));
+  }
+
   function handleRemove(id: string) {
     setSections((prev) => prev.filter((s) => s.id !== id));
     startTransition(() => deleteSection(id));
@@ -229,7 +246,8 @@ export function SectionTab({
           <div className="bg-zinc-50 border-b border-zinc-100 flex items-center gap-3 px-4 py-3">
             <span className="size-4 shrink-0" />
             <span className="flex-1 text-xs font-medium text-muted-foreground">섹션</span>
-            <span className="shrink-0 text-xs font-medium text-muted-foreground">활성</span>
+            <span className="shrink-0 w-11 text-center text-xs font-medium text-muted-foreground">홈</span>
+            <span className="shrink-0 w-11 text-center text-xs font-medium text-muted-foreground">활성</span>
             <span className="size-4 shrink-0" />
             <span className="size-4 shrink-0" />
           </div>
@@ -253,6 +271,7 @@ export function SectionTab({
                   onEdit={openEdit}
                   onRemove={handleRemove}
                   onToggle={handleToggle}
+                  onSetHome={handleSetHome}
                 />
               ))}
             </SortableContext>

--- a/src/app/admin/home-curation/page.tsx
+++ b/src/app/admin/home-curation/page.tsx
@@ -47,6 +47,7 @@ export default async function HomeCurationPage({
           maxCount: true,
           order: true,
           isActive: true,
+          showOnHome: true,
         },
       }),
       prisma.post.findMany({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-noto-sans-kr), var(--font-noto-sans);
+  --font-sans: var(--font-plus-jakarta), var(--font-noto-sans-kr);
   --color-gray-900: var(--palette-gray-900);
 
   /* ── Typography Scale ───────────────── */
@@ -132,6 +132,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    letter-spacing: 0.01em;
   }
 }
 
@@ -141,7 +142,7 @@
 /* ── 공통 Pill 뱃지 스타일 ── */
 /* --pill-py (기본 py-0.75), --pill-fs (기본 text-sm) 를 부모에서 오버라이드 가능 */
 .pill-badge {
-  @apply inline-flex items-center gap-1 px-2 rounded-full font-medium leading-none;
+  @apply inline-flex items-center gap-1 px-2 rounded-full font-semibold leading-none;
   padding-top: var(--pill-py, 0.1875rem);
   padding-bottom: var(--pill-py, 0.1875rem);
   font-size: var(--pill-fs, var(--text-xs));

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,7 +140,7 @@
 .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
 
 /* ── 공통 Pill 뱃지 스타일 ── */
-/* --pill-py (기본 py-0.75), --pill-fs (기본 text-sm) 를 부모에서 오버라이드 가능 */
+/* --pill-py (기본 py-0.75), --pill-fs (기본 text-xs, 12px) 를 부모에서 오버라이드 가능 */
 .pill-badge {
   @apply inline-flex items-center gap-1 px-2 rounded-full font-semibold leading-none;
   padding-top: var(--pill-py, 0.1875rem);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from "next";
-import { Noto_Sans, Noto_Sans_KR } from "next/font/google";
+import { Noto_Sans_KR, Plus_Jakarta_Sans } from "next/font/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ToastProvider } from "@/components/toast-provider";
 import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import { VercelAnalytics } from "@/components/VercelAnalytics";
 import "./globals.css";
 
-const notoSans = Noto_Sans({
-  variable: "--font-noto-sans",
+const plusJakarta = Plus_Jakarta_Sans({
+  variable: "--font-plus-jakarta",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
 const notoSansKR = Noto_Sans_KR({
@@ -55,7 +55,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" suppressHydrationWarning>
-      <body className={`${notoSans.variable} ${notoSansKR.variable} font-sans antialiased`} suppressHydrationWarning>
+      <body className={`${plusJakarta.variable} ${notoSansKR.variable} font-sans antialiased`} suppressHydrationWarning>
         <GoogleAnalytics />
         <ToastProvider>{children}</ToastProvider>
         <VercelAnalytics />

--- a/src/lib/post-queries.ts
+++ b/src/lib/post-queries.ts
@@ -7,12 +7,14 @@ export async function getPostsWithLabels(
   options?: {
     take?: number;
     orderBy?: Prisma.PostOrderByWithRelationInput | Prisma.PostOrderByWithRelationInput[];
+    cursor?: string;
   }
 ) {
   return prisma.post.findMany({
     where,
     take: options?.take,
     orderBy: options?.orderBy,
+    ...(options?.cursor ? { cursor: { id: options.cursor }, skip: 1 } : {}),
     select: {
       id: true,
       slug: true,


### PR DESCRIPTION
## 작업 내용
기존 캐러셀 나열형 Home을 "큐레이션 헤더 + 무한 피드" 구조로 개편했습니다.
상단은 에디토리얼 히어로 + 시그니처 캐러셀 1개로 가볍게 두고, 그 아래 큰 사진 중심의 Latest 무한 피드를 메인으로 배치해 리텐션을 강화합니다.
Highlights / Following 두 탭 모두 피드형으로 통일하고, Home 캐러셀은 최대 1개로 제한했습니다.

작업 중 폰트·타이포그래피 개선과 scroll-to-top UX도 함께 반영했습니다.

Closes #140

## 변경 사항

**피드형 전환 (이슈 본 작업)**
- [x] FeedCard 컴포넌트 구현 (대형 썸네일, 태그 칩, 장소명, 1줄 스니펫)
- [x] FeedCard 로딩 스켈레톤 구현
- [x] cursor 기반 무한 스크롤 데이터 페칭 (offset 미사용)
- [x] Intersection Observer 기반 하단 감지 및 다음 페이지 로드
- [x] 피드 응답 페이로드 최소화 (본문 전체 미포함)
- [x] Highlights 탭: 히어로 1 + 큐레이션 캐러셀 1 + Latest 무한 피드 조립
- [x] Following 탭: 히어로/캐러셀 없이 팔로우 토픽 기반 무한 피드만 렌더
- [x] 빈 상태 처리 (Following 미팔로우 시, 결과 없음 시)
- [x] 에러 상태 처리 (페칭 실패 시 재시도 UI)

**타이포그래피 / UX 개선 (추가 작업)**
- [x] 전역 폰트를 Plus Jakarta Sans로 교체 (한글은 Noto Sans KR 폴백)
- [x] 라벨 칩 굵기 상향 (medium → semibold), 전역 자간 미세 조정
- [x] 카드 제목 줄간격 조정 및 배너 제목 클램프 깨짐 수정
- [x] scroll-to-top 버튼 신규 (전 user 페이지 공통, window 스크롤 기준)
- [x] Follow 탭 → Following 으로 라벨 변경
- [x] 클린코드 점검 후속 수정 (button type, 테마 배경 토큰, rAF cleanup 등)

## 스크린샷
<!-- Home 피드 / Following 탭 / scroll-to-top 버튼 캡처 첨부 -->
<img width="321" height="697" alt="Screenshot 2026-05-23 at 4 33 11 PM" src="https://github.com/user-attachments/assets/f8e48c0d-f3b7-4b77-8c1c-42ff807728bc" />
<img width="321" height="697" alt="Screenshot 2026-05-23 at 4 33 03 PM" src="https://github.com/user-attachments/assets/badd2bb1-45e5-4dba-a71d-fe7ade03207f" />
<img width="321" height="697" alt="Screenshot 2026-05-23 at 4 32 46 PM" src="https://github.com/user-attachments/assets/4af7e8a7-cac0-4b6e-bc55-46b2ac0b8669" />
<img width="321" height="697" alt="Screenshot 2026-05-23 at 4 32 36 PM" src="https://github.com/user-attachments/assets/1135353e-3b09-43c6-b0a6-ddc0127b97fd" />



## 리뷰 포인트
- cursor 기반 무한 페칭의 cursor 설계와 페이로드 최소화 범위가 적절한지
- Following 탭의 다중 토픽 fetch 동작 (현재 getFilteredPosts는 AND 교집합 — 이번 범위에서 의도대로인지)
- scroll-to-top: window 스크롤 기준 동작 + useEffect cleanup(rAF 취소 포함) 검토
- 폰트 전역 교체 후 한글 폴백이 의도대로 적용되는지