### PR TITLE
release(hotfix): 2026-05-25

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,9 +4,6 @@ import { POST_SLUG_REDIRECTS } from "./src/lib/post-redirects";
 const nextConfig: NextConfig = {
   async redirects() {
     return [
-      { source: "/explore", destination: "/discover", permanent: true },
-      { source: "/explore/hall/:id*", destination: "/discover/hall/:id*", permanent: true },
-      { source: "/my-map", destination: "/discover", permanent: false },
       ...POST_SLUG_REDIRECTS.map((r) => ({
         source: `/posts/${r.from}`,
         destination: `/posts/${r.to}`,


### PR DESCRIPTION
## 작업 내용
prod에 /discover 페이지가 아직 없는데 /explore→/discover 301 리다이렉트가 cherry-pick에 딸려가서 /explore 접속 시 404 발생. 해당 redirect 3건(/explore, /explore/hall, /my-map) 제거. slug redirect 110건은 유지.

## 변경 사항
- next.config.ts: /explore, /my-map redirect 3건 삭제 (0 add / 3 del)

## 리뷰 포인트
- slug redirect(POST_SLUG_REDIRECTS)는 그대로 유지됨
- dev 브랜치엔 이 redirect 유지(거긴 /discover 존재) — main에서만 제거
- Preview에서 /explore 200 확인 완료