### PR TITLE
feat: URL filter params, tag group filter, and curation region filter

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -526,6 +526,7 @@ model CuratedSection {
   filterTopicId  String?     @db.Uuid
   filterTagId    String?     @db.Uuid
   filterTagGroup String?
+  filterRegion   String?
   maxCount       Int         @default(10)
   order          Int         @default(0)
   isActive       Boolean     @default(true)

--- a/src/app/(user)/discover/_components/DiscoverActiveFacets.tsx
+++ b/src/app/(user)/discover/_components/DiscoverActiveFacets.tsx
@@ -12,11 +12,14 @@ interface Props {
   query: string;
   appliedTopicIds: string[];
   appliedTagIds: string[];
+  appliedTagGroupKeys: string[];
   topicChipMap: Map<string, ChipInfo>;
   tagChipMap: Map<string, ChipInfo>;
+  tagGroupChipMap: Map<string, ChipInfo>;
   onClearQuery: () => void;
   onRemoveTopic: (id: string) => void;
   onRemoveTag: (id: string) => void;
+  onRemoveTagGroup: (key: string) => void;
   eventCollections?: ActiveEventCollection[];
   onEventCollectionClick?: (id: string) => void;
   quickTopicChip?: ChipInfo | null;
@@ -30,11 +33,14 @@ export function DiscoverActiveFacets({
   query,
   appliedTopicIds,
   appliedTagIds,
+  appliedTagGroupKeys,
   topicChipMap,
   tagChipMap,
+  tagGroupChipMap,
   onClearQuery,
   onRemoveTopic,
   onRemoveTag,
+  onRemoveTagGroup,
   eventCollections = [],
   onEventCollectionClick,
   quickTopicChip,
@@ -44,7 +50,7 @@ export function DiscoverActiveFacets({
   onRegionChange,
 }: Props) {
   const hasQuery = query.trim() !== "";
-  const hasFilters = appliedTopicIds.length > 0 || appliedTagIds.length > 0 || appliedRegion !== null;
+  const hasFilters = appliedTopicIds.length > 0 || appliedTagIds.length > 0 || appliedTagGroupKeys.length > 0 || appliedRegion !== null;
   const hasEventCollections = eventCollections.length > 0;
   const showEventCollections = hasEventCollections && !hasQuery && !hasFilters;
   const showQuickChips = !hasQuery && !hasFilters && !!quickTopicChip;
@@ -144,6 +150,23 @@ export function DiscoverActiveFacets({
                 color={chip.fg}
                 className="shrink-0 !px-3 h-7 !font-semibold shadow-sm active:opacity-70"
                 onClick={() => onRemoveTag(id)}
+              >
+                <X className="size-3" />
+              </LabelBadge>
+            );
+          })}
+          {appliedTagGroupKeys.map((key) => {
+            const chip = tagGroupChipMap.get(key);
+            if (!chip) return null;
+            return (
+              <LabelBadge
+                key={key}
+                as="button"
+                text={chip.label}
+                background={chip.bg}
+                color={chip.fg}
+                className="shrink-0 !px-3 h-7 !font-semibold shadow-sm active:opacity-70"
+                onClick={() => onRemoveTagGroup(key)}
               >
                 <X className="size-3" />
               </LabelBadge>

--- a/src/app/(user)/discover/_components/ExploreMapView.tsx
+++ b/src/app/(user)/discover/_components/ExploreMapView.tsx
@@ -404,8 +404,10 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
 
   const tagGroupChipMap = useMemo(() => {
     const map = new Map<string, ChipInfo>();
-    for (const g of tagGroups)
-      map.set(g.group, { id: g.group, label: g.nameEn, bg: g.colorHex, fg: g.textColorHex });
+    for (const g of tagGroups) {
+      const bg = labelBackground({ text: "", colorHex: g.colorHex, colorHex2: g.colorHex2, gradientDir: g.gradientDir, gradientStop: g.gradientStop, textColorHex: g.textColorHex });
+      map.set(g.group, { id: g.group, label: g.nameEn, bg, fg: g.textColorHex });
+    }
     return map;
   }, [tagGroups]);
 

--- a/src/app/(user)/discover/_components/ExploreMapView.tsx
+++ b/src/app/(user)/discover/_components/ExploreMapView.tsx
@@ -66,7 +66,7 @@ function postMatchesFilters(post: MapPost, topicIds: string[], tagIds: string[],
     topicIds.length > 0 &&
     post.topics.some((t) => topicIds.some((id) => topicMatchesFilter(t, id)));
   const tagHit = tagIds.length > 0 && post.tags.some((tag) => tagIds.includes(tag.id));
-  const groupHit = tagGroupKeys.length > 0 && post.tags.some((tag) => tagGroupKeys.includes(tag.group));
+  const groupHit = tagGroupKeys.length > 0 && post.allTagGroups.some((g) => tagGroupKeys.includes(g));
   return topicHit || tagHit || groupHit;
 }
 

--- a/src/app/(user)/discover/_components/ExploreMapView.tsx
+++ b/src/app/(user)/discover/_components/ExploreMapView.tsx
@@ -61,23 +61,25 @@ function calcEventPassesFilter(
   return matchesSearch && matchesCategory && matchesSaved;
 }
 
-function postMatchesFilters(post: MapPost, topicIds: string[], tagIds: string[]): boolean {
+function postMatchesFilters(post: MapPost, topicIds: string[], tagIds: string[], tagGroupKeys: string[]): boolean {
   const topicHit =
     topicIds.length > 0 &&
     post.topics.some((t) => topicIds.some((id) => topicMatchesFilter(t, id)));
   const tagHit = tagIds.length > 0 && post.tags.some((tag) => tagIds.includes(tag.id));
-  return topicHit || tagHit;
+  const groupHit = tagGroupKeys.length > 0 && post.tags.some((tag) => tagGroupKeys.includes(tag.group));
+  return topicHit || tagHit || groupHit;
 }
 
 function placeMatchesFilters(
   place: Pick<MapPlace, "posts" | "area">,
   topicIds: string[],
   tagIds: string[],
+  tagGroupKeys: string[],
   region: string | null
 ): boolean {
   if (region !== null && getPlaceRegionSlug(place.area) !== region) return false;
-  if (topicIds.length === 0 && tagIds.length === 0) return true;
-  return place.posts.some((post) => postMatchesFilters(post, topicIds, tagIds));
+  if (topicIds.length === 0 && tagIds.length === 0 && tagGroupKeys.length === 0) return true;
+  return place.posts.some((post) => postMatchesFilters(post, topicIds, tagIds, tagGroupKeys));
 }
 
 // 토픽 매칭은 항상 태그보다 위. 같은 급 안에서는 먼저 선택한 필터 기준.
@@ -164,9 +166,11 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [stagedTopicIds, setStagedTopicIds] = useState<string[]>([]);
   const [stagedTagIds, setStagedTagIds] = useState<string[]>([]);
+  const [stagedTagGroupKeys, setStagedTagGroupKeys] = useState<string[]>([]);
   const [stagedRegion, setStagedRegion] = useState<string | null>(null);
   const [appliedTopicIds, setAppliedTopicIds] = useState<string[]>([]);
   const [appliedTagIds, setAppliedTagIds] = useState<string[]>([]);
+  const [appliedTagGroupKeys, setAppliedTagGroupKeys] = useState<string[]>([]);
   const [appliedRegion, setAppliedRegion] = useState<string | null>(null);
   const [locating, setLocating] = useState(false);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
@@ -218,6 +222,7 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
     );
     if (parsed.topicIds.length > 0) { setAppliedTopicIds(parsed.topicIds); setStagedTopicIds(parsed.topicIds); }
     if (parsed.tagIds.length > 0) { setAppliedTagIds(parsed.tagIds); setStagedTagIds(parsed.tagIds); }
+    if (parsed.tagGroupKeys.length > 0) { setAppliedTagGroupKeys(parsed.tagGroupKeys); setStagedTagGroupKeys(parsed.tagGroupKeys); }
     if (parsed.region && availableCities.some((c) => c.slug === parsed.region)) {
       setAppliedRegion(parsed.region);
       setStagedRegion(parsed.region);
@@ -278,9 +283,10 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
     router.replace(`?${params.toString()}`);
   }
 
-  function commitFilters(next: { topicIds: string[]; tagIds: string[]; region: string | null }) {
+  function commitFilters(next: { topicIds: string[]; tagIds: string[]; tagGroupKeys: string[]; region: string | null }) {
     setAppliedTopicIds(next.topicIds);
     setAppliedTagIds(next.tagIds);
+    setAppliedTagGroupKeys(next.tagGroupKeys);
     setAppliedRegion(next.region);
     const params = serializeFilterParams(next, { topicTree, tagGroups }, new URLSearchParams(searchParams.toString()));
     const qs = params.toString();
@@ -426,7 +432,7 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
   );
   const isEventMode = activeEventData !== null;
 
-  const hasFilters = appliedTopicIds.length > 0 || appliedTagIds.length > 0 || appliedRegion !== null;
+  const hasFilters = appliedTopicIds.length > 0 || appliedTagIds.length > 0 || appliedTagGroupKeys.length > 0 || appliedRegion !== null;
   const isResultMode = !isEventMode && (query.trim() !== "" || hasFilters);
   const hasRegionChips = !isEventMode && availableCities.length >= 2;
   // 이벤트 모드는 EventSearchBar(검색+칩)가 항상 떠 있어 동일한 top reserve가 필요.
@@ -453,14 +459,14 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
   const filteredPlaces = useMemo(() => {
     if (!hasFilters) return searchedPlaces;
     const matched = searchedPlaces.filter((p) =>
-      placeMatchesFilters(p, appliedTopicIds, appliedTagIds, appliedRegion)
+      placeMatchesFilters(p, appliedTopicIds, appliedTagIds, appliedTagGroupKeys, appliedRegion)
     );
     return [...matched].sort(
       (a, b) =>
         placeMatchScore(b, appliedTopicIds, appliedTagIds) -
         placeMatchScore(a, appliedTopicIds, appliedTagIds)
     );
-  }, [searchedPlaces, hasFilters, appliedTopicIds, appliedTagIds, appliedRegion]);
+  }, [searchedPlaces, hasFilters, appliedTopicIds, appliedTagIds, appliedTagGroupKeys, appliedRegion]);
 
   const suggestions = useMemo((): DiscoverSuggestion[] => {
     const q = query.trim().toLowerCase();
@@ -645,25 +651,26 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
 
   const exitResultMode = () => {
     setQuery("");
-    commitFilters({ topicIds: [], tagIds: [], region: null });
+    commitFilters({ topicIds: [], tagIds: [], tagGroupKeys: [], region: null });
   };
 
   const openFilter = () => {
     setStagedTopicIds(appliedTopicIds);
     setStagedTagIds(appliedTagIds);
+    setStagedTagGroupKeys(appliedTagGroupKeys);
     setStagedRegion(appliedRegion);
     setIsFilterOpen(true);
   };
   const applyFilters = () => {
-    commitFilters({ topicIds: stagedTopicIds, tagIds: stagedTagIds, region: stagedRegion });
+    commitFilters({ topicIds: stagedTopicIds, tagIds: stagedTagIds, tagGroupKeys: stagedTagGroupKeys, region: stagedRegion });
     setIsFilterOpen(false);
     setSheetState("half");
   };
-  const resetStaged = () => { setStagedTopicIds([]); setStagedTagIds([]); setStagedRegion(null); };
+  const resetStaged = () => { setStagedTopicIds([]); setStagedTagIds([]); setStagedTagGroupKeys([]); setStagedRegion(null); };
   const removeAppliedTopic = (id: string) =>
-    commitFilters({ topicIds: appliedTopicIds.filter((x) => x !== id), tagIds: appliedTagIds, region: appliedRegion });
+    commitFilters({ topicIds: appliedTopicIds.filter((x) => x !== id), tagIds: appliedTagIds, tagGroupKeys: appliedTagGroupKeys, region: appliedRegion });
   const removeAppliedTag = (id: string) =>
-    commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds.filter((x) => x !== id), region: appliedRegion });
+    commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds.filter((x) => x !== id), tagGroupKeys: appliedTagGroupKeys, region: appliedRegion });
 
   const toggleTopic = (id: string) =>
     setStagedTopicIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
@@ -751,11 +758,11 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
           onEventCollectionClick={(slug) => setCollectionSlug(slug)}
           quickTopicChip={btsChipInfo}
           onQuickTopicClick={() => {
-            if (btsTopicId) commitFilters({ topicIds: [btsTopicId], tagIds: appliedTagIds, region: appliedRegion });
+            if (btsTopicId) commitFilters({ topicIds: [btsTopicId], tagIds: appliedTagIds, tagGroupKeys: appliedTagGroupKeys, region: appliedRegion });
           }}
           regions={availableCities}
           appliedRegion={appliedRegion}
-          onRegionChange={(slug) => commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds, region: slug })}
+          onRegionChange={(slug) => commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds, tagGroupKeys: appliedTagGroupKeys, region: slug })}
         />
       )}
 

--- a/src/app/(user)/discover/_components/ExploreMapView.tsx
+++ b/src/app/(user)/discover/_components/ExploreMapView.tsx
@@ -5,7 +5,8 @@ import { Loader2, LocateFixed, Maximize } from "lucide-react";
 import { useToast } from "../../_hooks/useToast";
 import { dedupeEventMarkers } from "@/lib/event-utils";
 import { EVENT_RED, getDDay, sortEventMarkers } from "@/lib/event-format";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { parseFilterParams, serializeFilterParams } from "@/lib/filter-params";
 import { InteractiveMap, type FocusCameraHandle } from "@/components/maps/InteractiveMap";
 import { PlaceBottomSheet } from "@/components/maps/PlaceBottomSheet";
 import { PlaceListSheet, getSheetHeight, type PlaceListSheetState } from "@/components/maps/PlaceListSheet";
@@ -129,12 +130,6 @@ function findTopicIdBySlug(topicTree: Level0TopicDeep[], slug: string): string |
   return null;
 }
 
-function findTagIdBySlug(tagGroups: TagGroupWithTags[], slug: string): string | null {
-  for (const group of tagGroups)
-    for (const tag of group.tags)
-      if (tag.slug === slug) return tag.id;
-  return null;
-}
 
 interface Props {
   allPlaces: (MapPlace & { isSaved?: boolean })[];
@@ -150,6 +145,7 @@ interface Props {
 export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], tagGroups, topicTree, isLoggedIn, eventCollections = [], eventMapData = {} }: Props) {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const pathname = usePathname();
 
   const isSavedView = searchParams.get("saved") === "1";
   const selectedPlaceId = searchParams.get("place");
@@ -211,23 +207,20 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
     }
   }, [restored, clear]);
 
-  // URL ?topic=<slug> / ?tag=<slug> / ?region=<slug> → 마운트 1회 초기 필터 적용
+  // URL ?topics=<slug,…> / ?tags=<slug,…> / ?region=<slug> → 마운트 1회 초기 필터 적용
   useEffect(() => {
     if (urlFilterInitRef.current) return;
     urlFilterInitRef.current = true;
-    const topicSlug = searchParams.get("topic");
-    const tagSlug = searchParams.get("tag");
-    const regionSlug = searchParams.get("region");
-    if (topicSlug) {
-      const id = findTopicIdBySlug(topicTree, topicSlug);
-      if (id) setAppliedTopicIds([id]);
-    }
-    if (tagSlug) {
-      const id = findTagIdBySlug(tagGroups, tagSlug);
-      if (id) setAppliedTagIds([id]);
-    }
-    if (regionSlug && availableCities.some((c) => c.slug === regionSlug)) {
-      setAppliedRegion(regionSlug);
+    const parsed = parseFilterParams(
+      new URLSearchParams(searchParams.toString()),
+      topicTree,
+      tagGroups
+    );
+    if (parsed.topicIds.length > 0) { setAppliedTopicIds(parsed.topicIds); setStagedTopicIds(parsed.topicIds); }
+    if (parsed.tagIds.length > 0) { setAppliedTagIds(parsed.tagIds); setStagedTagIds(parsed.tagIds); }
+    if (parsed.region && availableCities.some((c) => c.slug === parsed.region)) {
+      setAppliedRegion(parsed.region);
+      setStagedRegion(parsed.region);
     }
   }, [searchParams, topicTree, tagGroups, availableCities]);
 
@@ -283,6 +276,15 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
       params.delete("place");
     }
     router.replace(`?${params.toString()}`);
+  }
+
+  function commitFilters(next: { topicIds: string[]; tagIds: string[]; region: string | null }) {
+    setAppliedTopicIds(next.topicIds);
+    setAppliedTagIds(next.tagIds);
+    setAppliedRegion(next.region);
+    const params = serializeFilterParams(next, { topicTree, tagGroups }, new URLSearchParams(searchParams.toString()));
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   }
 
   const handleLocateMe = () => {
@@ -643,9 +645,7 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
 
   const exitResultMode = () => {
     setQuery("");
-    setAppliedTopicIds([]);
-    setAppliedTagIds([]);
-    setAppliedRegion(null);
+    commitFilters({ topicIds: [], tagIds: [], region: null });
   };
 
   const openFilter = () => {
@@ -655,17 +655,15 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
     setIsFilterOpen(true);
   };
   const applyFilters = () => {
-    setAppliedTopicIds(stagedTopicIds);
-    setAppliedTagIds(stagedTagIds);
-    setAppliedRegion(stagedRegion);
+    commitFilters({ topicIds: stagedTopicIds, tagIds: stagedTagIds, region: stagedRegion });
     setIsFilterOpen(false);
     setSheetState("half");
   };
   const resetStaged = () => { setStagedTopicIds([]); setStagedTagIds([]); setStagedRegion(null); };
   const removeAppliedTopic = (id: string) =>
-    setAppliedTopicIds((prev) => prev.filter((x) => x !== id));
+    commitFilters({ topicIds: appliedTopicIds.filter((x) => x !== id), tagIds: appliedTagIds, region: appliedRegion });
   const removeAppliedTag = (id: string) =>
-    setAppliedTagIds((prev) => prev.filter((x) => x !== id));
+    commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds.filter((x) => x !== id), region: appliedRegion });
 
   const toggleTopic = (id: string) =>
     setStagedTopicIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
@@ -753,11 +751,11 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
           onEventCollectionClick={(slug) => setCollectionSlug(slug)}
           quickTopicChip={btsChipInfo}
           onQuickTopicClick={() => {
-            if (btsTopicId) setAppliedTopicIds([btsTopicId]);
+            if (btsTopicId) commitFilters({ topicIds: [btsTopicId], tagIds: appliedTagIds, region: appliedRegion });
           }}
           regions={availableCities}
           appliedRegion={appliedRegion}
-          onRegionChange={setAppliedRegion}
+          onRegionChange={(slug) => commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds, region: slug })}
         />
       )}
 

--- a/src/app/(user)/discover/_components/ExploreMapView.tsx
+++ b/src/app/(user)/discover/_components/ExploreMapView.tsx
@@ -402,6 +402,13 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
     return map;
   }, [tagGroups]);
 
+  const tagGroupChipMap = useMemo(() => {
+    const map = new Map<string, ChipInfo>();
+    for (const g of tagGroups)
+      map.set(g.group, { id: g.group, label: g.nameEn, bg: g.colorHex, fg: g.textColorHex });
+    return map;
+  }, [tagGroups]);
+
   const btsTopicId = useMemo(() => findTopicIdBySlug(topicTree, "bts"), [topicTree]);
   const btsChipInfo = useMemo(
     () => (btsTopicId ? (topicChipMap.get(btsTopicId) ?? null) : null),
@@ -671,6 +678,8 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
     commitFilters({ topicIds: appliedTopicIds.filter((x) => x !== id), tagIds: appliedTagIds, tagGroupKeys: appliedTagGroupKeys, region: appliedRegion });
   const removeAppliedTag = (id: string) =>
     commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds.filter((x) => x !== id), tagGroupKeys: appliedTagGroupKeys, region: appliedRegion });
+  const removeAppliedTagGroup = (key: string) =>
+    commitFilters({ topicIds: appliedTopicIds, tagIds: appliedTagIds, tagGroupKeys: appliedTagGroupKeys.filter((k) => k !== key), region: appliedRegion });
 
   const toggleTopic = (id: string) =>
     setStagedTopicIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
@@ -749,11 +758,14 @@ export function ExploreMapView({ allPlaces, savedPostIds, savedEventIds = [], ta
           query={query}
           appliedTopicIds={appliedTopicIds}
           appliedTagIds={appliedTagIds}
+          appliedTagGroupKeys={appliedTagGroupKeys}
           topicChipMap={topicChipMap}
           tagChipMap={tagChipMap}
+          tagGroupChipMap={tagGroupChipMap}
           onClearQuery={handleClearQuery}
           onRemoveTopic={removeAppliedTopic}
           onRemoveTag={removeAppliedTag}
+          onRemoveTagGroup={removeAppliedTagGroup}
           eventCollections={eventCollections}
           onEventCollectionClick={(slug) => setCollectionSlug(slug)}
           quickTopicChip={btsChipInfo}

--- a/src/app/admin/home-curation/_actions/home-curation-actions.ts
+++ b/src/app/admin/home-curation/_actions/home-curation-actions.ts
@@ -21,6 +21,7 @@ export type SectionFormData = {
   filterTopicId?: string;
   filterTagId?: string;
   filterTagGroup?: string;
+  filterRegion?: string;
   maxCount: number;
   isActive: boolean;
 };
@@ -85,6 +86,7 @@ export async function createSection(data: SectionFormData) {
       filterTopicId: data.filterTopicId || null,
       filterTagId: data.filterTagId || null,
       filterTagGroup: data.filterTagGroup || null,
+      filterRegion: data.filterRegion || null,
       maxCount: data.maxCount,
       isActive: data.isActive,
       order: (max?.order ?? 0) + 1,
@@ -105,6 +107,7 @@ export async function updateSection(id: string, data: SectionFormData) {
       filterTopicId: data.filterTopicId || null,
       filterTagId: data.filterTagId || null,
       filterTagGroup: data.filterTagGroup || null,
+      filterRegion: data.filterRegion || null,
       maxCount: data.maxCount,
       isActive: data.isActive,
     },

--- a/src/app/admin/home-curation/_actions/home-curation-actions.ts
+++ b/src/app/admin/home-curation/_actions/home-curation-actions.ts
@@ -3,6 +3,13 @@
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import type { SectionType, ContentType } from "@prisma/client";
+import { getCurrentUser } from "@/lib/auth";
+
+async function requireEditor() {
+  const user = await getCurrentUser();
+  if (!user || user.role === "USER") throw new Error("권한이 없습니다.");
+  return user;
+}
 
 // ─── 타입 ─────────────────────────────────────────────────────────────────────
 
@@ -26,6 +33,7 @@ function revalidate() {
 // ─── 배너 액션 ────────────────────────────────────────────────────────────────
 
 export async function addBanner(postId: string) {
+  await requireEditor();
   const existing = await prisma.homeBanner.findFirst({ where: { postId } });
   if (existing) return;
   const max = await prisma.homeBanner.findFirst({
@@ -39,11 +47,13 @@ export async function addBanner(postId: string) {
 }
 
 export async function removeBanner(bannerId: string) {
+  await requireEditor();
   await prisma.homeBanner.delete({ where: { id: bannerId } });
   revalidate();
 }
 
 export async function reorderBanners(orderedIds: string[]) {
+  await requireEditor();
   await Promise.all(
     orderedIds.map((id, i) =>
       prisma.homeBanner.update({ where: { id }, data: { order: i } })
@@ -53,6 +63,7 @@ export async function reorderBanners(orderedIds: string[]) {
 }
 
 export async function toggleBannerActive(bannerId: string, isActive: boolean) {
+  await requireEditor();
   await prisma.homeBanner.update({ where: { id: bannerId }, data: { isActive } });
   revalidate();
 }
@@ -60,6 +71,7 @@ export async function toggleBannerActive(bannerId: string, isActive: boolean) {
 // ─── 섹션 액션 ────────────────────────────────────────────────────────────────
 
 export async function createSection(data: SectionFormData) {
+  await requireEditor();
   const max = await prisma.curatedSection.findFirst({
     orderBy: { order: "desc" },
     select: { order: true },
@@ -82,6 +94,7 @@ export async function createSection(data: SectionFormData) {
 }
 
 export async function updateSection(id: string, data: SectionFormData) {
+  await requireEditor();
   await prisma.curatedSection.update({
     where: { id },
     data: {
@@ -100,11 +113,13 @@ export async function updateSection(id: string, data: SectionFormData) {
 }
 
 export async function deleteSection(id: string) {
+  await requireEditor();
   await prisma.curatedSection.delete({ where: { id } });
   revalidate();
 }
 
 export async function reorderSections(orderedIds: string[]) {
+  await requireEditor();
   await Promise.all(
     orderedIds.map((id, i) =>
       prisma.curatedSection.update({ where: { id }, data: { order: i } })
@@ -114,11 +129,13 @@ export async function reorderSections(orderedIds: string[]) {
 }
 
 export async function toggleSectionActive(id: string, isActive: boolean) {
+  await requireEditor();
   await prisma.curatedSection.update({ where: { id }, data: { isActive } });
   revalidate();
 }
 
 export async function toggleHomeSection(id: string, showOnHome: boolean) {
+  await requireEditor();
   await prisma.curatedSection.update({ where: { id }, data: { showOnHome } });
   revalidate();
 }

--- a/src/app/admin/home-curation/_components/SectionDialog.tsx
+++ b/src/app/admin/home-curation/_components/SectionDialog.tsx
@@ -48,6 +48,7 @@ type TopicOption = {
 };
 type TagOption = { id: string; nameKo: string; name: string; group: string };
 type TagGroupOption = { group: string; nameEn: string; colorHex: string; textColorHex: string };
+type RegionOption = { label: string; slug: string };
 
 interface SectionDialogProps {
   open: boolean;
@@ -56,6 +57,7 @@ interface SectionDialogProps {
   topics: TopicOption[];
   tags: TagOption[];
   tagGroups: TagGroupOption[];
+  regions: RegionOption[];
   editTarget?: {
     id: string;
     titleEn: string;
@@ -65,6 +67,7 @@ interface SectionDialogProps {
     filterTopicId: string | null;
     filterTagId: string | null;
     filterTagGroup: string | null;
+    filterRegion: string | null;
     maxCount: number;
     isActive: boolean;
   };
@@ -78,6 +81,7 @@ const INITIAL: SectionFormData = {
   filterTopicId: "",
   filterTagId: "",
   filterTagGroup: "",
+  filterRegion: "",
   maxCount: 20,
   isActive: true,
 };
@@ -492,6 +496,7 @@ export function SectionDialog({
   topics,
   tags,
   tagGroups,
+  regions,
   editTarget,
 }: SectionDialogProps) {
   const [form, setForm] = useState<SectionFormData>(INITIAL);
@@ -516,6 +521,7 @@ export function SectionDialog({
               filterTopicId: editTarget.filterTopicId ?? "",
               filterTagId: editTarget.filterTagId ?? "",
               filterTagGroup: editTarget.filterTagGroup ?? "",
+              filterRegion: editTarget.filterRegion ?? "",
               maxCount: editTarget.maxCount,
               isActive: editTarget.isActive,
             }
@@ -789,6 +795,23 @@ export function SectionDialog({
                       }}
                     />
                   </div>
+                  {regions.length > 0 && (
+                    <div className="space-y-1.5">
+                      <p className="text-xs text-zinc-500">지역 필터</p>
+                      <select
+                        value={form.filterRegion || ""}
+                        onChange={(e) => set("filterRegion", e.target.value)}
+                        className="w-full h-9 px-3 rounded-lg border border-zinc-200 bg-white text-sm hover:border-zinc-400 focus:outline-none focus:border-zinc-500 transition-colors"
+                      >
+                        <option value="">전체</option>
+                        {regions.map((r) => (
+                          <option key={r.slug} value={r.slug}>
+                            {r.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
                   {/* 표시 개수 스테퍼 */}
                   <div className="flex items-center justify-between pt-1 border-t border-zinc-200">
                     <p className="text-xs text-zinc-500">표시 개수 <span className="text-zinc-400">(최대 20개)</span></p>

--- a/src/app/admin/home-curation/_components/SectionTab.tsx
+++ b/src/app/admin/home-curation/_components/SectionTab.tsx
@@ -32,6 +32,7 @@ import type { SectionType, ContentType } from "@prisma/client";
 type TopicOption = { id: string; nameKo: string; nameEn: string; level: number; parentId: string | null; colorHex: string | null; textColorHex: string | null };
 type TagOption = { id: string; nameKo: string; name: string; group: string };
 type TagGroupOption = { group: string; nameEn: string; colorHex: string; textColorHex: string };
+type RegionOption = { label: string; slug: string };
 
 export type SectionRow = {
   id: string;
@@ -42,6 +43,7 @@ export type SectionRow = {
   filterTopicId: string | null;
   filterTagId: string | null;
   filterTagGroup: string | null;
+  filterRegion: string | null;
   maxCount: number;
   order: number;
   isActive: boolean;
@@ -163,12 +165,14 @@ export function SectionTab({
   topics,
   tags,
   tagGroups,
+  regions,
 }: {
   initialSections: SectionRow[];
   posts: PickablePost[];
   topics: TopicOption[];
   tags: TagOption[];
   tagGroups: TagGroupOption[];
+  regions: RegionOption[];
 }) {
   const [sections, setSections] = useState(initialSections);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -286,6 +290,7 @@ export function SectionTab({
         topics={topics}
         tags={tags}
         tagGroups={tagGroups}
+        regions={regions}
         editTarget={
           editTarget
             ? {
@@ -297,6 +302,7 @@ export function SectionTab({
                 filterTopicId: editTarget.filterTopicId,
                 filterTagId: editTarget.filterTagId,
                 filterTagGroup: editTarget.filterTagGroup,
+                filterRegion: editTarget.filterRegion,
                 maxCount: editTarget.maxCount,
                 isActive: editTarget.isActive,
               }

--- a/src/app/admin/home-curation/page.tsx
+++ b/src/app/admin/home-curation/page.tsx
@@ -11,7 +11,7 @@ export default async function HomeCurationPage({
 }) {
   const { tab = "banner" } = await searchParams;
 
-  const [homeBanners, sections, publishedPosts, topics, tags, tagGroups] =
+  const [homeBanners, sections, publishedPosts, topics, tags, tagGroups, areas] =
     await Promise.all([
       prisma.homeBanner.findMany({
         orderBy: { order: "asc" },
@@ -44,6 +44,7 @@ export default async function HomeCurationPage({
           filterTopicId: true,
           filterTagId: true,
           filterTagGroup: true,
+          filterRegion: true,
           maxCount: true,
           order: true,
           isActive: true,
@@ -101,6 +102,11 @@ export default async function HomeCurationPage({
         orderBy: { sortOrder: "asc" },
         select: { group: true, nameEn: true, colorHex: true, textColorHex: true },
       }),
+      prisma.area.findMany({
+        where: { level: 0, isActive: true, nameEn: { not: null } },
+        orderBy: { sortOrder: "asc" },
+        select: { nameKo: true, nameEn: true },
+      }),
     ]);
 
   const bannerRows: BannerRow[] = homeBanners.map((b) => ({
@@ -117,6 +123,7 @@ export default async function HomeCurationPage({
 
   const sectionRows: SectionRow[] = sections;
   const tagGroupMap = new Map(tagGroups.map((g) => [g.group, g]));
+  const regionOptions = areas.map((a) => ({ label: a.nameKo, slug: a.nameEn!.toLowerCase() }));
 
   const pickablePosts: PickablePost[] = publishedPosts.map((p) => ({
     id: p.id,
@@ -192,6 +199,7 @@ export default async function HomeCurationPage({
           topics={topics}
           tags={tags}
           tagGroups={tagGroups}
+          regions={regionOptions}
         />
       )}
     </div>

--- a/src/lib/curation-queries.ts
+++ b/src/lib/curation-queries.ts
@@ -114,6 +114,8 @@ export function getPostMoreHref(section: CuratedSectionWithSlug): string {
   if (section.type === "MANUAL") return "/discover";
   const topicSlugs = section.filterTopicId && section.filterTopic?.slug ? [section.filterTopic.slug] : [];
   const tagSlugs = section.filterTagId && section.filterTag?.slug ? [section.filterTag.slug] : [];
-  if (topicSlugs.length === 0 && tagSlugs.length === 0) return "/discover";
-  return buildDiscoverHref({ topicSlugs, tagSlugs });
+  // filterTagId 없을 때만 그룹 폴백 (getSectionData의 우선순위와 동일)
+  const tagGroupKeys = !section.filterTagId && section.filterTagGroup ? [section.filterTagGroup] : [];
+  if (topicSlugs.length === 0 && tagSlugs.length === 0 && tagGroupKeys.length === 0) return "/discover";
+  return buildDiscoverHref({ topicSlugs, tagSlugs, tagGroupKeys });
 }

--- a/src/lib/curation-queries.ts
+++ b/src/lib/curation-queries.ts
@@ -45,6 +45,15 @@ export async function getCuratedSections(opts: { showOnHome?: boolean }): Promis
 export async function getSectionData(sections: CuratedSection[]): Promise<SectionData[]> {
   return Promise.all(
     sections.map(async (section): Promise<SectionData> => {
+      const regionAreaFilter = section.filterRegion
+        ? {
+            OR: [
+              { level: 0, nameEn: { equals: section.filterRegion, mode: "insensitive" as const } },
+              { level: 1, parent: { nameEn: { equals: section.filterRegion, mode: "insensitive" as const } } },
+            ],
+          }
+        : null;
+
       if (section.contentType === "RECREESHOT") {
         const items = await prisma.reCreeshot.findMany({
           where: {
@@ -57,6 +66,7 @@ export async function getSectionData(sections: CuratedSection[]): Promise<Sectio
               : section.filterTagGroup
               ? { reCreeshotTags: { some: { tag: { group: section.filterTagGroup } } } }
               : {}),
+            ...(regionAreaFilter ? { place: { area: regionAreaFilter } } : {}),
           },
           orderBy: { createdAt: "desc" },
           take: section.maxCount,
@@ -93,6 +103,7 @@ export async function getSectionData(sections: CuratedSection[]): Promise<Sectio
             : section.filterTagGroup
             ? { postTags: { some: { tag: { group: section.filterTagGroup } } } }
             : {}),
+          ...(regionAreaFilter ? { postPlaces: { some: { place: { area: regionAreaFilter } } } } : {}),
         },
         {
           take: section.maxCount,
@@ -116,6 +127,6 @@ export function getPostMoreHref(section: CuratedSectionWithSlug): string {
   const tagSlugs = section.filterTagId && section.filterTag?.slug ? [section.filterTag.slug] : [];
   // filterTagId 없을 때만 그룹 폴백 (getSectionData의 우선순위와 동일)
   const tagGroupKeys = !section.filterTagId && section.filterTagGroup ? [section.filterTagGroup] : [];
-  if (topicSlugs.length === 0 && tagSlugs.length === 0 && tagGroupKeys.length === 0) return "/discover";
-  return buildDiscoverHref({ topicSlugs, tagSlugs, tagGroupKeys });
+  if (topicSlugs.length === 0 && tagSlugs.length === 0 && tagGroupKeys.length === 0 && !section.filterRegion) return "/discover";
+  return buildDiscoverHref({ topicSlugs, tagSlugs, tagGroupKeys, region: section.filterRegion || undefined });
 }

--- a/src/lib/curation-queries.ts
+++ b/src/lib/curation-queries.ts
@@ -112,9 +112,8 @@ export async function getSectionData(sections: CuratedSection[]): Promise<Sectio
  */
 export function getPostMoreHref(section: CuratedSectionWithSlug): string {
   if (section.type === "MANUAL") return "/discover";
-  if (section.filterTopicId && section.filterTopic?.slug)
-    return buildDiscoverHref({ topicSlugs: [section.filterTopic.slug] });
-  if (section.filterTagId && section.filterTag?.slug)
-    return buildDiscoverHref({ tagSlugs: [section.filterTag.slug] });
-  return "/discover";
+  const topicSlugs = section.filterTopicId && section.filterTopic?.slug ? [section.filterTopic.slug] : [];
+  const tagSlugs = section.filterTagId && section.filterTag?.slug ? [section.filterTag.slug] : [];
+  if (topicSlugs.length === 0 && tagSlugs.length === 0) return "/discover";
+  return buildDiscoverHref({ topicSlugs, tagSlugs });
 }

--- a/src/lib/curation-queries.ts
+++ b/src/lib/curation-queries.ts
@@ -2,6 +2,7 @@
 import { prisma } from "@/lib/prisma";
 import { getPostsWithLabels, type PostItem } from "@/lib/post-queries";
 import type { CuratedSection } from "@prisma/client";
+import { buildDiscoverHref } from "@/lib/filter-params";
 
 // ─── 타입 ─────────────────────────────────────────────────────────────────────
 
@@ -111,7 +112,9 @@ export async function getSectionData(sections: CuratedSection[]): Promise<Sectio
  */
 export function getPostMoreHref(section: CuratedSectionWithSlug): string {
   if (section.type === "MANUAL") return "/discover";
-  if (section.filterTopicId && section.filterTopic?.slug) return `/discover?topic=${section.filterTopic.slug}`;
-  if (section.filterTagId && section.filterTag?.slug) return `/discover?tag=${section.filterTag.slug}`;
+  if (section.filterTopicId && section.filterTopic?.slug)
+    return buildDiscoverHref({ topicSlugs: [section.filterTopic.slug] });
+  if (section.filterTagId && section.filterTag?.slug)
+    return buildDiscoverHref({ tagSlugs: [section.filterTag.slug] });
   return "/discover";
 }

--- a/src/lib/filter-params.ts
+++ b/src/lib/filter-params.ts
@@ -138,3 +138,20 @@ export function serializeFilterParams(
 
   return params;
 }
+
+/**
+ * slug를 직접 받아 Discover URL을 조립.
+ * slug→id 변환 없이 URL 파라미터 이름만 중앙화.
+ */
+export function buildDiscoverHref(opts: {
+  topicSlugs?: string[];
+  tagSlugs?: string[];
+  region?: string | null;
+}): string {
+  const params = new URLSearchParams();
+  if (opts.topicSlugs?.length) params.set("topics", opts.topicSlugs.join(","));
+  if (opts.tagSlugs?.length) params.set("tags", opts.tagSlugs.join(","));
+  if (opts.region) params.set("region", opts.region);
+  const qs = params.toString();
+  return qs ? `/discover?${qs}` : "/discover";
+}

--- a/src/lib/filter-params.ts
+++ b/src/lib/filter-params.ts
@@ -4,6 +4,7 @@ import type { TagGroupWithTags } from "./filter-queries";
 export interface FilterState {
   topicIds: string[];
   tagIds: string[];
+  tagGroupKeys: string[];
   region: string | null;
 }
 
@@ -80,10 +81,12 @@ export function parseFilterParams(
 ): FilterState {
   const rawTopics = searchParams.get("topics");
   const rawTags = searchParams.get("tags");
+  const rawTagGroups = searchParams.get("tagGroups");
   const rawRegion = searchParams.get("region");
 
   const topicSlugs = rawTopics ? rawTopics.split(",").filter(Boolean) : [];
   const tagSlugs = rawTags ? rawTags.split(",").filter(Boolean) : [];
+  const rawTagGroupKeys = rawTagGroups ? rawTagGroups.split(",").filter(Boolean) : [];
 
   const topicIds = topicSlugs
     .map((slug) => topicSlugToId(topicTree, slug))
@@ -93,7 +96,10 @@ export function parseFilterParams(
     .map((slug) => tagSlugToId(tagGroups, slug))
     .filter((id): id is string => id !== null);
 
-  return { topicIds, tagIds, region: rawRegion || null };
+  const validGroupKeys = new Set(tagGroups.map((g) => g.group));
+  const tagGroupKeys = rawTagGroupKeys.filter((k) => validGroupKeys.has(k));
+
+  return { topicIds, tagIds, tagGroupKeys, region: rawRegion || null };
 }
 
 /**
@@ -130,6 +136,12 @@ export function serializeFilterParams(
     params.delete("tags");
   }
 
+  if (state.tagGroupKeys.length > 0) {
+    params.set("tagGroups", state.tagGroupKeys.join(","));
+  } else {
+    params.delete("tagGroups");
+  }
+
   if (state.region !== null) {
     params.set("region", state.region);
   } else {
@@ -146,11 +158,13 @@ export function serializeFilterParams(
 export function buildDiscoverHref(opts: {
   topicSlugs?: string[];
   tagSlugs?: string[];
+  tagGroupKeys?: string[];
   region?: string | null;
 }): string {
   const params = new URLSearchParams();
   if (opts.topicSlugs?.length) params.set("topics", opts.topicSlugs.join(","));
   if (opts.tagSlugs?.length) params.set("tags", opts.tagSlugs.join(","));
+  if (opts.tagGroupKeys?.length) params.set("tagGroups", opts.tagGroupKeys.join(","));
   if (opts.region) params.set("region", opts.region);
   const qs = params.toString();
   return qs ? `/discover?${qs}` : "/discover";

--- a/src/lib/filter-params.ts
+++ b/src/lib/filter-params.ts
@@ -1,0 +1,140 @@
+import type { Level0TopicDeep } from "./topic-queries";
+import type { TagGroupWithTags } from "./filter-queries";
+
+export interface FilterState {
+  topicIds: string[];
+  tagIds: string[];
+  region: string | null;
+}
+
+export interface FilterLookups {
+  topicTree: Level0TopicDeep[];
+  tagGroups: TagGroupWithTags[];
+}
+
+// ExploreMapView의 칩 레벨 결정 로직과 동일 (KPOP은 L2, 나머지는 L2 또는 L1)
+const KPOP_NAME = "K-POP";
+
+function topicSlugToId(topicTree: Level0TopicDeep[], slug: string): string | null {
+  for (const root of topicTree) {
+    const l1s = root.children;
+    if (l1s.length === 0) continue;
+    if (root.nameEn === KPOP_NAME) {
+      for (const l1 of l1s)
+        for (const l2 of l1.children)
+          if (l2.slug === slug) return l2.id;
+      continue;
+    }
+    const hasL2 = l1s.some((l1) => l1.children.length > 0);
+    if (!hasL2) {
+      for (const l1 of l1s)
+        if (l1.slug === slug) return l1.id;
+    } else {
+      for (const l1 of l1s)
+        for (const l2 of l1.children)
+          if (l2.slug === slug) return l2.id;
+    }
+  }
+  return null;
+}
+
+function topicIdToSlug(topicTree: Level0TopicDeep[], id: string): string | null {
+  for (const root of topicTree) {
+    if (root.id === id) return root.slug;
+    for (const l1 of root.children) {
+      if (l1.id === id) return l1.slug;
+      for (const l2 of l1.children) {
+        if (l2.id === id) return l2.slug;
+        for (const l3 of l2.children)
+          if (l3.id === id) return l3.slug;
+      }
+    }
+  }
+  return null;
+}
+
+function tagSlugToId(tagGroups: TagGroupWithTags[], slug: string): string | null {
+  for (const group of tagGroups)
+    for (const tag of group.tags)
+      if (tag.slug === slug) return tag.id;
+  return null;
+}
+
+function tagIdToSlug(tagGroups: TagGroupWithTags[], id: string): string | null {
+  for (const group of tagGroups)
+    for (const tag of group.tags)
+      if (tag.id === id) return tag.slug;
+  return null;
+}
+
+/**
+ * URL searchParams → FilterState
+ * - ?topics=bts,twice  → topicIds (slug → id 변환, 못 찾은 slug 버림)
+ * - ?tags=concert      → tagIds   (slug → id 변환, 못 찾은 slug 버림)
+ * - ?region=seoul      → region   (문자열 그대로, 없으면 null)
+ */
+export function parseFilterParams(
+  searchParams: URLSearchParams,
+  topicTree: Level0TopicDeep[],
+  tagGroups: TagGroupWithTags[]
+): FilterState {
+  const rawTopics = searchParams.get("topics");
+  const rawTags = searchParams.get("tags");
+  const rawRegion = searchParams.get("region");
+
+  const topicSlugs = rawTopics ? rawTopics.split(",").filter(Boolean) : [];
+  const tagSlugs = rawTags ? rawTags.split(",").filter(Boolean) : [];
+
+  const topicIds = topicSlugs
+    .map((slug) => topicSlugToId(topicTree, slug))
+    .filter((id): id is string => id !== null);
+
+  const tagIds = tagSlugs
+    .map((slug) => tagSlugToId(tagGroups, slug))
+    .filter((id): id is string => id !== null);
+
+  return { topicIds, tagIds, region: rawRegion || null };
+}
+
+/**
+ * FilterState → URLSearchParams
+ * - currentParams를 복사해서 시작 (saved/collection/place 등 기존 param 보존)
+ * - topicIds → slug → "topics"에 set, 비면 delete
+ * - tagIds   → slug → "tags"에   set, 비면 delete
+ * - region   → "region"에 set,       null이면 delete
+ */
+export function serializeFilterParams(
+  state: FilterState,
+  lookups: FilterLookups,
+  currentParams: URLSearchParams
+): URLSearchParams {
+  const params = new URLSearchParams(currentParams);
+
+  const topicSlugs = state.topicIds
+    .map((id) => topicIdToSlug(lookups.topicTree, id))
+    .filter((slug): slug is string => slug !== null);
+
+  if (topicSlugs.length > 0) {
+    params.set("topics", topicSlugs.join(","));
+  } else {
+    params.delete("topics");
+  }
+
+  const tagSlugs = state.tagIds
+    .map((id) => tagIdToSlug(lookups.tagGroups, id))
+    .filter((slug): slug is string => slug !== null);
+
+  if (tagSlugs.length > 0) {
+    params.set("tags", tagSlugs.join(","));
+  } else {
+    params.delete("tags");
+  }
+
+  if (state.region !== null) {
+    params.set("region", state.region);
+  } else {
+    params.delete("region");
+  }
+
+  return params;
+}


### PR DESCRIPTION
## 작업 내용
Discover 필터를 URL 파라미터로 공유 가능하게 만들고, 태그 그룹 필터를 신규 추가했으며, 큐레이션 섹션에 지역 필터를 붙였습니다. 작업 중 발견한 홈 큐레이션 Server Action의 권한 검증 누락(보안)도 함께 수정했습니다.

## 변경 사항
- [ ] Discover 필터(topic/tag/region)를 URL 파라미터로 직렬화·복원 — 필터 걸린 링크 공유 가능
- [ ] 큐레이션 섹션 See all → 필터 URL 이동 회귀 수정 (단수 ?topic= → 복수 ?topics=)
- [ ] 태그 그룹 필터 신규 추가 (?tagGroups=) — 코어 매칭 / active facet 칩 / 그라데이션 색상
- [ ] 태그 그룹 매칭을 allTagGroups 기준으로 (isVisible=false 태그 누락 엣지 수정)
- [ ] [보안] 홈 큐레이션 Server Action 10개에 EDITOR 이상 권한 가드(requireEditor) 추가
- [ ] 큐레이션 섹션 지역 필터: filterRegion 컬럼 추가 + 어드민 드롭다운(도시 전체) + 저장
- [ ] 지역 See all 연결 + 섹션 콘텐츠 필터 (level-0/level-1 OR로 Discover 매칭과 일치)

## 스크린샷
<!-- UI 변경이 있으면 첨부. 없으면 삭제 -->


## 리뷰 포인트
<!-- 리뷰어가 특히 봐줬으면 하는 부분. 없으면 삭제 -->

