### PR TITLE
feature: anonymous feedback form on feed and discover

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -764,3 +764,11 @@ model Sticker {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model Feedback {
+  id        String   @id @default(uuid()) @db.Uuid
+  content   String
+  email     String?
+  source    String   // "feed" | "discover" | 기타 진입점 식별자
+  createdAt DateTime @default(now())
+}

--- a/src/app/(user)/_actions/feedback-actions.ts
+++ b/src/app/(user)/_actions/feedback-actions.ts
@@ -17,8 +17,8 @@ export async function submitFeedback(input: {
   const content = input.content?.trim() ?? "";
   if (content.length < 10)
     return { error: "Please write at least 10 characters." };
-  if (content.length > 1000)
-    return { error: "Feedback must be 1000 characters or fewer." };
+  if (content.length > 500)
+    return { error: "Feedback must be 500 characters or fewer." };
 
   if (!isValidSource(input.source))
     return { error: "Invalid source." };

--- a/src/app/(user)/_actions/feedback-actions.ts
+++ b/src/app/(user)/_actions/feedback-actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+
+const VALID_SOURCES = ["feed", "discover"] as const;
+type FeedbackSource = (typeof VALID_SOURCES)[number];
+
+function isValidSource(s: string): s is FeedbackSource {
+  return (VALID_SOURCES as readonly string[]).includes(s);
+}
+
+export async function submitFeedback(input: {
+  content: string;
+  email?: string | null;
+  source: string;
+}): Promise<{ success: true } | { error: string }> {
+  const content = input.content?.trim() ?? "";
+  if (content.length < 10)
+    return { error: "Please write at least 10 characters." };
+  if (content.length > 1000)
+    return { error: "Feedback must be 1000 characters or fewer." };
+
+  if (!isValidSource(input.source))
+    return { error: "Invalid source." };
+
+  const email = input.email?.trim() || null;
+  if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+    return { error: "Please enter a valid email address." };
+
+  try {
+    await prisma.feedback.create({
+      data: { content, email, source: input.source },
+    });
+    return { success: true };
+  } catch (e) {
+    console.error("submitFeedback failed:", e);
+    return { error: "Something went wrong. Please try again later." };
+  }
+}

--- a/src/app/(user)/discover/_components/HotTabStub.tsx
+++ b/src/app/(user)/discover/_components/HotTabStub.tsx
@@ -1,4 +1,5 @@
 import type { ActiveEventCollection, EventCollectionForMap } from "@/lib/event-collection-queries";
+import { FeedbackForm } from "@/components/feedback/FeedbackForm";
 import type { CuratedSectionWithSlug, SectionData } from "@/lib/curation-types";
 import type { TagGroupColorMap } from "@/lib/post-labels";
 import { EventVerticalCarousel } from "@/components/maps/EventVerticalCarousel";
@@ -50,6 +51,10 @@ export function HotTabStub({ eventCollections, eventMapData, sections, sectionDa
           </HScrollSection>
         );
       })}
+
+      <div className="px-4">
+        <FeedbackForm source="discover" />
+      </div>
     </div>
   );
 }

--- a/src/app/(user)/feed/page.tsx
+++ b/src/app/(user)/feed/page.tsx
@@ -289,10 +289,6 @@ export default async function FeedPage({ searchParams }: { searchParams: Promise
         )
       ) : (
         <>
-          <div className="px-4 mb-4">
-            <FeedbackForm source="feed" />
-          </div>
-
           {hasBanners && (
             <div className="mb-4">
               <HomeBannerCarousel banners={bannerItems} />
@@ -349,8 +345,12 @@ export default async function FeedPage({ searchParams }: { searchParams: Promise
               </HScrollSection>
             );
           })}
+          <div className="px-4 mb-4">
+            <FeedbackForm source="feed" />
+          </div>
+
           <div className="flex items-center justify-between mb-3 px-4 mt-2">
-            <h2 className="font-bold text-lg">Latest</h2>
+            <h2 className="font-bold text-lg">Fresh Drops</h2>
           </div>
           <div className="px-4">
             <InfiniteFeed

--- a/src/app/(user)/feed/page.tsx
+++ b/src/app/(user)/feed/page.tsx
@@ -47,6 +47,7 @@ import {
   type EventCollectionForMap,
 } from "@/lib/event-collection-queries";
 import { EventVerticalCarousel } from "@/components/maps/EventVerticalCarousel";
+import { FeedbackForm } from "@/components/feedback/FeedbackForm";
 
 // ─── 탭 바 ───────────────────────────────────────────────────────────────────
 
@@ -288,6 +289,10 @@ export default async function FeedPage({ searchParams }: { searchParams: Promise
         )
       ) : (
         <>
+          <div className="px-4 mb-4">
+            <FeedbackForm source="feed" />
+          </div>
+
           {hasBanners && (
             <div className="mb-4">
               <HomeBannerCarousel banners={bannerItems} />

--- a/src/components/feedback/FeedbackForm.tsx
+++ b/src/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { submitFeedback } from "@/app/(user)/_actions/feedback-actions";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+interface Props {
+  source: "feed" | "discover";
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function FeedbackForm({ source }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [email, setEmail] = useState("");
+  const [content, setContent] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const trimmedEmail = email.trim();
+  const trimmedContent = content.trim();
+  const emailValid = !trimmedEmail || EMAIL_RE.test(trimmedEmail);
+  const contentValid = trimmedContent.length >= 10 && trimmedContent.length <= 500;
+  const canSubmit = contentValid && emailValid && status === "idle";
+
+  function handleEmailChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setEmail(e.target.value);
+    if (status === "error") setStatus("idle");
+  }
+
+  function handleContentChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    setContent(e.target.value);
+    if (status === "error") setStatus("idle");
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setStatus("submitting");
+    const res = await submitFeedback({
+      content: trimmedContent,
+      email: trimmedEmail || null,
+      source,
+    });
+    if ("error" in res) {
+      setStatus("error");
+      setErrorMsg(res.error);
+    } else {
+      setStatus("success");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="rounded-xl border border-border bg-muted/40 px-4 py-3 text-center text-sm text-muted-foreground">
+        Thanks for your feedback! 🙌
+      </div>
+    );
+  }
+
+  if (!expanded) {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-xl border border-border px-4 py-3">
+        <p className="text-sm text-muted-foreground">
+          Help us make reCree better — share your thoughts.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setExpanded(true)}
+          className="shrink-0 rounded-full"
+        >
+          Give feedback
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-xl border border-border bg-background px-4 py-4">
+      <p className="text-sm font-medium">Share your thoughts</p>
+
+      <div className="space-y-1">
+        <Input
+          type="email"
+          placeholder="Email (optional)"
+          value={email}
+          onChange={handleEmailChange}
+          disabled={status === "submitting"}
+          className="text-sm"
+        />
+        {!emailValid && (
+          <p className="text-xs text-destructive">Invalid email address.</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <Textarea
+          placeholder="What's on your mind? (10–500 characters)"
+          value={content}
+          onChange={handleContentChange}
+          disabled={status === "submitting"}
+          rows={4}
+          maxLength={500}
+          className="resize-none text-sm"
+        />
+        <div className="flex items-center justify-between">
+          <span
+            className={`text-xs ${
+              content.length > 500
+                ? "text-destructive"
+                : "text-muted-foreground"
+            }`}
+          >
+            {content.length}/500
+          </span>
+          {status === "error" && (
+            <span className="text-xs text-destructive">{errorMsg}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setExpanded(false);
+            if (status === "error") setStatus("idle");
+          }}
+          disabled={status === "submitting"}
+          className="rounded-full"
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="rounded-full bg-brand text-black hover:bg-brand/90 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {status === "submitting" ? "Sending…" : "Send"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/feedback/FeedbackForm.tsx
+++ b/src/components/feedback/FeedbackForm.tsx
@@ -55,7 +55,7 @@ export function FeedbackForm({ source }: Props) {
 
   if (status === "success") {
     return (
-      <div className="rounded-xl border border-border bg-muted/40 px-4 py-3 text-center text-sm text-muted-foreground">
+      <div className="rounded-xl bg-white shadow-[0_2px_16px_rgba(0,0,0,0.06)] px-4 py-3 text-center text-sm text-muted-foreground">
         Thanks for your feedback! 🙌
       </div>
     );
@@ -63,7 +63,7 @@ export function FeedbackForm({ source }: Props) {
 
   if (!expanded) {
     return (
-      <div className="flex items-center justify-between gap-4 rounded-xl border border-border px-4 py-3">
+      <div className="flex items-center justify-between gap-4 rounded-xl bg-white shadow-[0_2px_16px_rgba(0,0,0,0.06)] px-4 py-3">
         <p className="text-sm text-muted-foreground">
           Help us make reCree better — share your thoughts.
         </p>
@@ -80,7 +80,7 @@ export function FeedbackForm({ source }: Props) {
   }
 
   return (
-    <div className="space-y-3 rounded-xl border border-border bg-background px-4 py-4">
+    <div className="space-y-3 rounded-xl bg-white shadow-[0_2px_16px_rgba(0,0,0,0.06)] px-4 py-4">
       <p className="text-sm font-medium">Share your thoughts</p>
 
       <div className="space-y-1">
@@ -92,8 +92,12 @@ export function FeedbackForm({ source }: Props) {
           disabled={status === "submitting"}
           className="text-sm"
         />
-        {!emailValid && (
+        {!emailValid ? (
           <p className="text-xs text-destructive">Invalid email address.</p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Leave your email for early updates — we won&apos;t use it for anything else.
+          </p>
         )}
       </div>
 


### PR DESCRIPTION
## 작업 내용
<!-- 무엇을 했나요? 한두 줄로 설명 -->
익명 피드백 수집 기능 추가. 로그인 없이 이메일(선택)+의견(필수)을 제출할 수 있는
토글형 폼을 /feed와 /discover 지도 Hot 탭에 배치. 제출은 Server Action(Prisma)으로만
가능하고, 테이블은 RLS로 클라이언트 직접 접근 차단.

- Feedback 테이블 추가 (id/content/email?/source/createdAt)
- submitFeedback Server Action (서버 검증 + insert, 익명 허용)
- FeedbackForm 재사용 컴포넌트 (접힘→펼침 토글, 로딩/성공/에러 상태)
- /feed(큐레이션 섹션 아래) + /discover Hot 탭(맨 밑) 배치, source로 진입점 구분

## 변경 사항
- [ ] Feedback 테이블 + RLS enable (SQL 직접 실행, migration 파일 없음)
- [ ] submitFeedback Server Action — content 10~500자·source 화이트리스트·email 형식 서버 검증
- [ ] FeedbackForm 컴포넌트 — 토글, 글자수 카운터, 상태별 UI(submitting/success/error)
- [ ] /feed·/discover 두 곳 배치, source="feed"|"discover"로 구분
- [ ] 이메일 목적 고지 문구 (early updates, 목적 외 미사용 명시)

## 스크린샷
<!-- UI 변경이 있으면 첨부. 없으면 삭제 -->
<img width="323" height="676" alt="image" src="https://github.com/user-attachments/assets/92101f9b-cdc7-4c52-a204-04c437e5a057" />
<img width="304" height="661" alt="image" src="https://github.com/user-attachments/assets/877224dd-1444-4231-98eb-bdcbdf353312" />


## 리뷰 포인트
<!-- 리뷰어가 특히 봐줬으면 하는 부분. 없으면 삭제 -->

